### PR TITLE
Add validation for the Timeout config.

### DIFF
--- a/ShipEngine.Tests/ShipEngineTests.cs
+++ b/ShipEngine.Tests/ShipEngineTests.cs
@@ -31,5 +31,20 @@ namespace ShipEngineTest
             Assert.Equal("A ShipEngine API key must be specified", ex.Message);
             Assert.Null(ex.RequestId);
         }
+
+        [Fact]
+        public void InvalidsTimeoutAtInstantiation()
+        {
+            var ex = Assert.Throws<ShipEngineException>(
+                () => new ShipEngine(
+                    new Config(apiKey: "TEST_1234", timeout: System.TimeSpan.FromSeconds(-1))
+                )
+            );
+            Assert.Equal(ErrorSource.ShipEngine, ex.ErrorSource);
+            Assert.Equal(ErrorType.Validation, ex.ErrorType);
+            Assert.Equal(ErrorCode.InvalidFieldValue, ex.ErrorCode);
+            Assert.Equal("Timeout must be greater than zero.", ex.Message);
+            Assert.Null(ex.RequestId);
+        }
     }
 }

--- a/ShipEngine/Config.cs
+++ b/ShipEngine/Config.cs
@@ -15,6 +15,14 @@ namespace ShipEngineSDK
                 throw new ShipEngineException(message, ErrorSource.ShipEngine, ErrorType.Validation, ErrorCode.FieldValueRequired);
             }
             ApiKey = apiKey;
+
+
+            if (timeout <= TimeSpan.Zero)
+            {
+                var message = "Timeout must be greater than zero.";
+                throw new ShipEngineException(message, ErrorSource.ShipEngine, ErrorType.Validation, ErrorCode.InvalidFieldValue);
+            }
+
             Timeout = timeout ?? TimeSpan.FromSeconds(5);
         }
     }


### PR DESCRIPTION
https://auctane.atlassian.net/browse/DX-1432
https://auctane.atlassian.net/browse/DX-1436

No need to test at the method level since every method based config has to pass the same validation as the global instance.