### PR TITLE
Fix customs_items parsing

### DIFF
--- a/ShipEngine.Tests/HttpResponseMocks/GetRatesWithShipmentDetails200Response.json
+++ b/ShipEngine.Tests/HttpResponseMocks/GetRatesWithShipmentDetails200Response.json
@@ -98,8 +98,20 @@
   "confirmation": "none",
   "customs": {
     "contents": "merchandise",
-    "customs_items": [],
-    "non_delivery": "return_to_sender"
+    "customs_items": [
+      {
+        "customs_item_id": "se-65172544",
+        "description": "Prescription",
+        "quantity": 1,
+        "value": 100.00,
+        "harmonized_tariff_code": null,
+        "country_of_origin": null,
+        "unit_of_measure": null
+      }
+    ],
+    "non_delivery": "return_to_sender",
+    "buyer_shipping_amount_paid": null,
+    "duties_paid": null
   },
   "external_order_id": null,
   "order_source_code": null,

--- a/ShipEngine.Tests/ShipEngineMethodTests/GetRatesFromShipmentTest.cs
+++ b/ShipEngine.Tests/ShipEngineMethodTests/GetRatesFromShipmentTest.cs
@@ -7,6 +7,7 @@ using ShipEngineSDK.GetRatesWithShipmentDetails;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
@@ -47,6 +48,26 @@ namespace ShipEngineTest
                         PostalCode = "95128",
                         CountryCode = Country.US,
                         Phone = "512-555-5555"
+                    },
+                    Customs = new Customs()
+                    {
+                        NonDelivery = NonDelivery.ReturnToSender,
+                        Contents = PackageContents.Merchandise,
+                        CustomsItems = new List<CustomsItem>()
+                        {
+                            new CustomsItem()
+                            {
+                                Description = "Merchandise",
+                                 CountryOfOrigin = Country.US,
+                                 Quantity = 1,
+                                 UnitOfMeasure = "each",
+                                 Value = new MonetaryValue()
+                                 {
+                                     Amount = 100D,
+                                     Currency = Currency.USD
+                                 }
+                            }
+                        }
                     },
                     Packages = new List<ShipmentPackage>() {
                         new ShipmentPackage() {
@@ -126,7 +147,8 @@ namespace ShipEngineTest
             Assert.Equal(DeliveryConfirmation.None, result.Confirmation);
 
             Assert.Equal(PackageContents.Merchandise, result.Customs.Contents);
-            Assert.Empty(result.Customs.CustomsItems);
+            Assert.NotEmpty(result.Customs.CustomsItems);
+            Assert.Equal(100D, result.Customs.CustomsItems.First().Value.Amount);
             Assert.Equal(NonDelivery.ReturnToSender, result.Customs.NonDelivery);
 
             Assert.Null(result.ExternalOrderId);

--- a/ShipEngine/Models/Dto/Common/Customs.cs
+++ b/ShipEngine/Models/Dto/Common/Customs.cs
@@ -46,6 +46,8 @@ namespace ShipEngineSDK.Common
         /// <summary>
         /// The declared customs value of each item
         /// </summary>
+        /// 
+        [JsonConverter(typeof(MonetaryValueConverter))]
         public MonetaryValue? Value { get; set; }
 
         /// <summary>

--- a/ShipEngine/Models/Dto/Common/MonetaryValue.cs
+++ b/ShipEngine/Models/Dto/Common/MonetaryValue.cs
@@ -2,7 +2,10 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
 using ShipEngineSDK.Common.Enums;
+using System;
+using System.Linq;
 
 namespace ShipEngineSDK.Common
 {
@@ -12,5 +15,28 @@ namespace ShipEngineSDK.Common
         public Currency? Currency { get; set; }
 
         public double? Amount { get; set; }
+    }
+
+    public class MonetaryValueConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(MonetaryValue);
+        }
+
+        public override object? ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.ValueType == typeof(double))
+            {
+                return new MonetaryValue() { Amount = (double)reader.Value };
+            }
+            return null;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/ShipEngine/Models/Dto/Common/MonetaryValue.cs
+++ b/ShipEngine/Models/Dto/Common/MonetaryValue.cs
@@ -17,24 +17,46 @@ namespace ShipEngineSDK.Common
         public double? Amount { get; set; }
     }
 
-    public class MonetaryValueConverter : JsonConverter
+    public class MonetaryValueConverter : JsonConverter<MonetaryValue>
     {
         public override bool CanWrite => false;
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType == typeof(MonetaryValue);
-        }
 
-        public override object? ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override MonetaryValue ReadJson(JsonReader reader, Type objectType, MonetaryValue existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            if (reader.ValueType == typeof(double))
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var response = new MonetaryValue();
+                while (reader.TokenType != JsonToken.EndObject)
+                {
+                    reader.Read();
+                    if (reader.TokenType == JsonToken.PropertyName)
+                    {
+                        switch (reader.Value)
+                        {
+                            case "amount":
+                                response.Amount = reader.ReadAsDouble();
+                                break;
+                            case "currency":
+                                if (Enum.TryParse(reader.ReadAsString(), true, out Currency currency))
+                                {
+                                    response.Currency = currency;
+                                }
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+                return response;
+            }
+            if (reader.TokenType == JsonToken.Float)
             {
                 return new MonetaryValue() { Amount = (double)reader.Value };
             }
-            return null;
+            return new MonetaryValue();
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, MonetaryValue value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
customs_items.value is an object of type MonetaryValue on the request, but a double on the response.  Based on other currency objects, I assume that this is an object that will be changing soon.  Rather than create a separate response object that will break in the future, I created a custom JsonConverter that will properly handle object, double, and null responses and put it into object format.

Updated test case with double response, which is what is currently returning, but also tested with other two cases.