### PR TITLE
chore: [ENGINE-5779] Add new error codes to the .Net SDK

### DIFF
--- a/ShipEngine/Enums/ErrorCode.cs
+++ b/ShipEngine/Enums/ErrorCode.cs
@@ -26,7 +26,7 @@ namespace ShipEngineSDK
         /// </summary>
         [EnumMember(Value = "carrier_conflict")]
         CarrierConflict,
-        
+
         // <summary>
         // You have selected to insure a package, however the carrier you are attempting to create a shipping label
         // for does not support declaring insurance on shipments.
@@ -53,7 +53,7 @@ namespace ShipEngineSDK
         /// </summary>
         [EnumMember(Value = "confirmation_not_supported")]
         ConfirmationNotSupported,
-        
+
         // <summary>
         // When shipping internationally, you must add a customs declaration which outlines the items you are shipping.
         // This is helpful to customs agents when your package enters it's destination country. This error arises when you
@@ -121,7 +121,7 @@ namespace ShipEngineSDK
         /// </summary>
         [EnumMember(Value = "invalid_charge_event")]
         InvalidChargeEvent,
-        
+
         // <summary>
         // When creating a label, if you set the date to an invalid date e.g. A date in the past
         // </summary>

--- a/ShipEngine/Enums/ErrorCode.cs
+++ b/ShipEngine/Enums/ErrorCode.cs
@@ -26,6 +26,13 @@ namespace ShipEngineSDK
         /// </summary>
         [EnumMember(Value = "carrier_conflict")]
         CarrierConflict,
+        
+        // <summary>
+        // You have selected to insure a package, however the carrier you are attempting to create a shipping label
+        // for does not support declaring insurance on shipments.
+        // </summary>
+        [EnumMember(Value = "carrier_insurance_not_supported")]
+        CarrierInsuranceNotSupported,
 
         /// <summary>
         /// This error means that you're trying to use a carrier that hasn't been setup yet.
@@ -46,6 +53,15 @@ namespace ShipEngineSDK
         /// </summary>
         [EnumMember(Value = "confirmation_not_supported")]
         ConfirmationNotSupported,
+        
+        // <summary>
+        // When shipping internationally, you must add a customs declaration which outlines the items you are shipping.
+        // This is helpful to customs agents when your package enters it's destination country. This error arises when you
+        // do not add a customs declaration to your shipment before attempting to create a shipping label for an 
+        // international shipmet.
+        // </summary>
+        [EnumMember(Value = "customs_items_required")]
+        CustomsItemsRequired,
 
         /// <summary>
         /// This error means that two or more fields in your API request are mutually exclusive or contain conflicting values.
@@ -105,6 +121,12 @@ namespace ShipEngineSDK
         /// </summary>
         [EnumMember(Value = "invalid_charge_event")]
         InvalidChargeEvent,
+        
+        // <summary>
+        // When creating a label, if you set the date to an invalid date e.g. A date in the past
+        // </summary>
+        [EnumMember(Value = "invalid_date")]
+        InvalidDate,
 
         /// <summary>
         /// One of the fields in your API request has an invalid value. The field_name property indicates which field is invalid.


### PR DESCRIPTION
# Add new error codes to the .Net SDK
This PR updates the `ShipEngine.ErrorCodes` enum to include recently added error codes in ShipEngine API.

## JIRA

[ENGINE-5778 | Add new error codes to the .Net SDK](https://auctane.atlassian.net/browse/ENGINE-5779)

## Acceptance Criteria
- [x] The `ShipEngine.ErrorCodes` enum is updated to include `invalid_date`, `customs_items_required`, and `carrier_insurance_not_supported`.

## Pull-Requests addressed by this change
- #59 

<br>
<img src="https://media.giphy.com/media/5xaOcLyjXRo4hX5UhSU/giphy.gif" alt="error-gif" width="100%" />