### PR TITLE
fix: [SE-161] Add content_description to the ShipmentPackage type

### DIFF
--- a/ShipEngine/Models/Dto/Common/ShipmentPackage.cs
+++ b/ShipEngine/Models/Dto/Common/ShipmentPackage.cs
@@ -11,7 +11,7 @@ namespace ShipEngineSDK.Common
         /// See: https://www.shipengine.com/docs/shipping/international/#bill-of-lading-for-shipments-to-and-from-mexico-carta-porte
         /// </summary>
         public string? ContentDescription { get; set; }
-        
+
         /// <summary>
         /// The package type, such as thick_envelope, small_flat_rate_box, large_package, etc. The code package indicates a custom or unknown package type
         /// </summary>

--- a/ShipEngine/Models/Dto/Common/ShipmentPackage.cs
+++ b/ShipEngine/Models/Dto/Common/ShipmentPackage.cs
@@ -6,6 +6,13 @@ namespace ShipEngineSDK.Common
     public class ShipmentPackage
     {
         /// <summary>
+        /// A recent regulation in Mexico requires a content description when shipping to this country
+        /// and when creating a bill of lading.
+        /// See: https://www.shipengine.com/docs/shipping/international/#bill-of-lading-for-shipments-to-and-from-mexico-carta-porte
+        /// </summary>
+        public string? ContentDescription { get; set; }
+        
+        /// <summary>
         /// The package type, such as thick_envelope, small_flat_rate_box, large_package, etc. The code package indicates a custom or unknown package type
         /// </summary>
         public string? PackageCode { get; set; }


### PR DESCRIPTION
## Add `content_description` to the ShipmentPackage type

This PR adds the `content_description` field to the `ShipmentPackage` field to allow the SDK users to set this field when [Shipping to Mexico](https://www.shipengine.com/docs/shipping/international/#bill-of-lading-for-shipments-to-and-from-mexico-carta-porte). 

> Note: This field was recently added and is required when shipping to Mexico.

## Issues addressed by this Pull-Request:
- #64 

## Type of change
- [x] Fix

## JIRA

- [SE-161 | Add content_description](https://auctane.atlassian.net/browse/SE-161)

## Acceptance Criteria
- [x] The ShipmentPackage type now has the 