### PR TITLE
Add LabelDownload to Package objects in Result for CreateLabelFromShipmentDetails and CreateLabelFromRate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,3 +92,9 @@ Added error mapping for NoRatesReturned
 ### Changed
 
 Added support for requesting retail rates
+
+## 1.1.8
+
+### Changed
+
+Added support LabelDownload to Package on CreateLabelFromShipment and CreateLabelFromRate

--- a/ShipEngine/Models/Dto/CreateLabelFromRate/Result.cs
+++ b/ShipEngine/Models/Dto/CreateLabelFromRate/Result.cs
@@ -229,5 +229,10 @@ namespace ShipEngineSDK.CreateLabelFromRate
         /// Package sequence
         /// </summary>
         public int? Sequence { get; set; }
+
+        /// <summary>
+        /// Reference to the various downloadable file formats for the generated label
+        /// </summary>
+        public Download? LabelDownload { get; set; }
     }
 }

--- a/ShipEngine/Models/Dto/CreateLabelFromShipmentDetails/Result.cs
+++ b/ShipEngine/Models/Dto/CreateLabelFromShipmentDetails/Result.cs
@@ -232,5 +232,10 @@ namespace ShipEngineSDK.CreateLabelFromShipmentDetails
         /// Package sequence
         /// </summary>
         public int? Sequence { get; set; }
+
+        /// <summary>
+        /// Reference to the various downloadable file formats for the generated label
+        /// </summary>
+        public Download? LabelDownload { get; set; }
     }
 }

--- a/ShipEngine/ShipEngine.csproj
+++ b/ShipEngine/ShipEngine.csproj
@@ -4,7 +4,7 @@
     <PackageId>ShipEngine</PackageId>
     <PackageTags>sdk;rest;api;shipping;rates;label;tracking;cost;address;validation;normalization;fedex;ups;usps;</PackageTags>
 
-    <Version>1.1.7</Version>
+    <Version>1.1.8</Version>
     <Authors>ShipEngine</Authors>
     <Company>ShipEngine</Company>
     <Summary>The official ShipEngine C# SDK for .NET</Summary>


### PR DESCRIPTION
This code adds a Download object to the CreateLabelFromShipmentDetails.Result.LabelPackage object and CreateLabelFromRate.Result.Package object. The property is named LabelDownload to match the ShipEngine JSON result.