### PR TITLE
feat: when enum not found, default to unspecified error code on serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,3 +98,9 @@ Added support for requesting retail rates
 ### Changed
 
 Added support LabelDownload to Package on CreateLabelFromShipment and CreateLabelFromRate
+
+## 1.1.9
+
+### Changed
+
+Added custom converter to fallback to default unspecified error code if value cannot be found in the enumeration

--- a/ShipEngine.Tests/HttpResponseMocks/GetRatesWithShipmentDetailsMissingErrorCodeEnum200Response.json
+++ b/ShipEngine.Tests/HttpResponseMocks/GetRatesWithShipmentDetailsMissingErrorCodeEnum200Response.json
@@ -1,0 +1,146 @@
+{
+  "rate_response": {
+    "rates": [],
+    "invalid_rates": [],
+    "rate_request_id": "se-139005222",
+    "shipment_id": "se-1506668211",
+    "created_at": "2024-04-23T16:09:08.1763483Z",
+    "status": "error",
+    "errors": [
+      {
+        "error_source": "carrier",
+        "error_type": "business_rules",
+        "error_code": "this_code_doesn't_exist",
+        "message": "A shipping carrier error occurred: Authentication failed.",
+        "carrier_id": "se-325186",
+        "carrier_code": "stamps_com",
+        "carrier_name": "Stamps.com"
+      }
+    ]
+  },
+  "shipment_id": "se-1506668211",
+  "carrier_id": "se-325186",
+  "service_code": "usps_priority_mail_international",
+  "external_shipment_id": null,
+  "shipment_number": null,
+  "ship_date": "2024-04-23T00:00:00Z",
+  "created_at": "2024-04-23T16:09:08.037Z",
+  "modified_at": "2024-04-23T16:09:08.02Z",
+  "shipment_status": "pending",
+  "ship_to": {
+    "geolocation": null,
+    "instructions": "",
+    "name": "Test Person",
+    "phone": "8889997777",
+    "email": null,
+    "company_name": "Test Company",
+    "address_line1": "123 Fake St",
+    "address_line2": "",
+    "address_line3": null,
+    "city_locality": "NEW YORK",
+    "state_province": "NY",
+    "postal_code": "10011-4758",
+    "country_code": "US",
+    "address_residential_indicator": "unknown"
+  },
+  "ship_from": {
+    "instructions": null,
+    "name": "Test Person",
+    "phone": "8889997777",
+    "email": null,
+    "company_name": null,
+    "address_line1": "321 Fake St.",
+    "address_line2": null,
+    "address_line3": null,
+    "city_locality": "Brooklyn",
+    "state_province": "NY",
+    "postal_code": "11207",
+    "country_code": "US",
+    "address_residential_indicator": "no"
+  },
+  "warehouse_id": null,
+  "return_to": {
+    "instructions": null,
+    "name": "Test Person",
+    "phone": "8889997777",
+    "email": null,
+    "company_name": null,
+    "address_line1": "321 Fake St.",
+    "address_line2": null,
+    "address_line3": null,
+    "city_locality": "Brooklyn",
+    "state_province": "NY",
+    "postal_code": "11207",
+    "country_code": "US",
+    "address_residential_indicator": "no"
+  },
+  "is_return": false,
+  "confirmation": "none",
+  "customs": null,
+  "external_order_id": null,
+  "order_source_code": null,
+  "advanced_options": {
+    "bill_to_account": null,
+    "bill_to_country_code": null,
+    "bill_to_party": null,
+    "bill_to_postal_code": null,
+    "contains_alcohol": false,
+    "delivered_duty_paid": false,
+    "non_machinable": false,
+    "saturday_delivery": false,
+    "dry_ice": false,
+    "dry_ice_weight": null,
+    "fedex_freight": null,
+    "third_party_consignee": false,
+    "ancillary_endorsements_option": null,
+    "freight_class": null,
+    "custom_field1": null,
+    "custom_field2": null,
+    "custom_field3": null,
+    "collect_on_delivery": null,
+    "return_pickup_attempts": null,
+    "additional_handling": false,
+    "own_document_upload": false,
+    "limited_quantity": false,
+    "event_notification": false
+  },
+  "comparison_rate_type": null,
+  "shipping_rule_id": null,
+  "insurance_provider": "none",
+  "tags": [],
+  "packages": [
+    {
+      "shipment_package_id": "se-645844381",
+      "package_id": "se-3",
+      "package_code": "package",
+      "package_name": "Package",
+      "weight": {
+        "value": 3.83,
+        "unit": "pound"
+      },
+      "dimensions": {
+        "unit": "inch",
+        "length": 0.00,
+        "width": 0.00,
+        "height": 0.00
+      },
+      "insured_value": {
+        "currency": "usd",
+        "amount": 0.00
+      },
+      "label_messages": {
+        "reference1": null,
+        "reference2": null,
+        "reference3": null
+      },
+      "external_package_id": null,
+      "content_description": null,
+      "products": null
+    }
+  ],
+  "total_weight": {
+    "value": 3.83,
+    "unit": "pound"
+  },
+  "items": []
+}

--- a/ShipEngine.Tests/ShipEngineMethodTests/GetRatesFromShipmentTest.cs
+++ b/ShipEngine.Tests/ShipEngineMethodTests/GetRatesFromShipmentTest.cs
@@ -249,5 +249,23 @@ namespace ShipEngineTest
             Assert.Equal("Retries must be greater than zero.", ex.Message);
             Assert.Null(ex.RequestId);
         }
+
+        [Fact]
+        public async void MissingErrorCodeEnumResolvesToUnspecified()
+        {
+            var apiKeyString = "TEST_bTYAskEX6tD7vv6u/cZ/M4LaUSWBJ219+8S1jgFcnkk";
+            var config = new Config(apiKey: apiKeyString);
+            var mockShipEngineFixture = new MockShipEngineFixture(config);
+
+            string json = File.ReadAllText(Path.Combine(Directory.GetCurrentDirectory(), "../../../HttpResponseMocks/GetRatesWithShipmentDetailsMissingErrorCodeEnum200Response.json"));
+
+            mockShipEngineFixture.StubRequest(HttpMethod.Post, "/v1/rates", System.Net.HttpStatusCode.OK, json);
+
+            var result = await mockShipEngineFixture.ShipEngine.GetRatesWithShipmentDetails(RatesParameters);
+
+            var errorCode = result.RateResponse.Errors.FirstOrDefault().ErrorCode;
+
+            Assert.Equal(ErrorCode.Unspecified, errorCode);
+        }
     }
 }

--- a/ShipEngine/Converters/ErrorCodeEnumConverter.cs
+++ b/ShipEngine/Converters/ErrorCodeEnumConverter.cs
@@ -1,0 +1,24 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+
+namespace ShipEngineSDK.Converters
+{
+    public class ErrorCodeEnumConverter : StringEnumConverter
+    {
+        public ErrorCode DefaultValue { get; set; }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+            JsonSerializer serializer)
+        {
+            try
+            {
+                return base.ReadJson(reader, objectType, existingValue, serializer);
+            }
+            catch (JsonSerializationException)
+            {
+                return DefaultValue;
+            }
+        }
+    }
+}

--- a/ShipEngine/Enums/ErrorCode.cs
+++ b/ShipEngine/Enums/ErrorCode.cs
@@ -27,10 +27,10 @@ namespace ShipEngineSDK
         [EnumMember(Value = "carrier_conflict")]
         CarrierConflict,
 
-        // <summary>
-        // You have selected to insure a package, however the carrier you are attempting to create a shipping label
-        // for does not support declaring insurance on shipments.
-        // </summary>
+        /// <summary>
+        /// You have selected to insure a package, however the carrier you are attempting to create a shipping label
+        /// for does not support declaring insurance on shipments.
+        /// </summary>
         [EnumMember(Value = "carrier_insurance_not_supported")]
         CarrierInsuranceNotSupported,
 
@@ -54,12 +54,12 @@ namespace ShipEngineSDK
         [EnumMember(Value = "confirmation_not_supported")]
         ConfirmationNotSupported,
 
-        // <summary>
-        // When shipping internationally, you must add a customs declaration which outlines the items you are shipping.
-        // This is helpful to customs agents when your package enters it's destination country. This error arises when you
-        // do not add a customs declaration to your shipment before attempting to create a shipping label for an 
-        // international shipmet.
-        // </summary>
+        /// <summary>
+        /// When shipping internationally, you must add a customs declaration which outlines the items you are shipping.
+        /// This is helpful to customs agents when your package enters it's destination country. This error arises when you
+        /// do not add a customs declaration to your shipment before attempting to create a shipping label for an 
+        /// international shipment.
+        /// </summary>
         [EnumMember(Value = "customs_items_required")]
         CustomsItemsRequired,
 
@@ -122,9 +122,9 @@ namespace ShipEngineSDK
         [EnumMember(Value = "invalid_charge_event")]
         InvalidChargeEvent,
 
-        // <summary>
-        // When creating a label, if you set the date to an invalid date e.g. A date in the past
-        // </summary>
+        /// <summary>
+        /// When creating a label, if you set the date to an invalid date e.g. A date in the past
+        /// </summary>
         [EnumMember(Value = "invalid_date")]
         InvalidDate,
 

--- a/ShipEngine/Models/Dto/Common/ShipEngineAPIError.cs
+++ b/ShipEngine/Models/Dto/Common/ShipEngineAPIError.cs
@@ -3,9 +3,12 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace ShipEngineSDK.Common
 {
+    using Converters;
+
     /// <summary>
     /// Error object returned by the ShipEngine API when an error occurs.
     /// <see href="https://www.shipengine.com/docs/errors/"/>
@@ -46,7 +49,7 @@ namespace ShipEngineSDK.Common
         /// <summary>
         /// The error code specified for the failed API Call
         /// </summary>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(ErrorCodeEnumConverter))]
         public ErrorCode ErrorCode { get; set; }
 
         /// <summary>

--- a/ShipEngine/ShipEngine.csproj
+++ b/ShipEngine/ShipEngine.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageId>ShipEngine</PackageId>
@@ -29,6 +29,10 @@
   <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="\" />
     <None Include="../LICENSE" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Converters\" />
   </ItemGroup>
 
 </Project>

--- a/ShipEngine/ShipEngine.csproj
+++ b/ShipEngine/ShipEngine.csproj
@@ -4,7 +4,7 @@
     <PackageId>ShipEngine</PackageId>
     <PackageTags>sdk;rest;api;shipping;rates;label;tracking;cost;address;validation;normalization;fedex;ups;usps;</PackageTags>
 
-    <Version>1.1.8</Version>
+    <Version>1.1.9</Version>
     <Authors>ShipEngine</Authors>
     <Company>ShipEngine</Company>
     <Summary>The official ShipEngine C# SDK for .NET</Summary>

--- a/ShipEngine/ShipEngineClient.cs
+++ b/ShipEngine/ShipEngineClient.cs
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 
 namespace ShipEngineSDK
 {
+    using Converters;
+
     /// <summary>
     /// ShipEngine Client is used for handling generic calls and settings that
     /// are needed for all ShipEngine API calls.
@@ -101,14 +103,15 @@ namespace ShipEngineSDK
 
             }
 
-            var result = JsonConvert.DeserializeObject<T>(contentString, new JsonSerializerSettings()
+            var settings = new JsonSerializerSettings()
             {
                 NullValueHandling = NullValueHandling.Include,
-                ContractResolver = new DefaultContractResolver
-                {
-                    NamingStrategy = new SnakeCaseNamingStrategy()
-                }
-            });
+                ContractResolver = new DefaultContractResolver { NamingStrategy = new SnakeCaseNamingStrategy() }
+            };
+
+            settings.Converters.Add(new ErrorCodeEnumConverter { DefaultValue = ErrorCode.Unspecified });
+
+            var result = JsonConvert.DeserializeObject<T>(contentString, settings);
 
             if (result != null)
             {


### PR DESCRIPTION
This change introduces a custom converter that populates a default unspecified error code if the json value cannot be found in the enumeration on serialization.

This will allow additions to be made to the error code enumeration in the ShipEngine code without immediately causing serialization exceptions here, which will help prevent unnecessary disruptions. 