### PR TITLE
feat: add method to initialize SDK with an httpClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,3 +116,13 @@ Updated to .NET 8.0, removed Newtonsoft.Json dependency, and updated to System.T
 ### Changed
 
 Updated references to use proper converter to resolve enum string values
+
+## 2.0.2
+
+### Changed
+
+- Adds the ability to initialize SDK with an HttpClient, and to make modifications to subsequent requests
+- Adds cancellation token to client
+- Adds HttpResponseMessage to ShipEngineException
+- Adds missing markdown
+- Redefines several properties as nullable reference types

--- a/ShipEngine/Models/Dto/Common/Customs.cs
+++ b/ShipEngine/Models/Dto/Common/Customs.cs
@@ -24,7 +24,7 @@ namespace ShipEngineSDK.Common
         /// <summary>
         /// Customs declarations for each item in the shipment.
         /// </summary>
-        public List<CustomsItem> CustomsItems { get; set; }
+        public List<CustomsItem>? CustomsItems { get; set; }
     }
 
     /// <summary>

--- a/ShipEngine/Models/Dto/CreateLabelFromRate/Result.cs
+++ b/ShipEngine/Models/Dto/CreateLabelFromRate/Result.cs
@@ -158,7 +158,7 @@ namespace ShipEngineSDK.CreateLabelFromRate
         /// <summary>
         /// The label's package(s).
         /// </summary>
-        public List<Package> Packages { get; set; }
+        public List<Package>? Packages { get; set; }
     }
 
     /// <summary>

--- a/ShipEngine/Models/Dto/CreateLabelFromShipmentDetails/Result.cs
+++ b/ShipEngine/Models/Dto/CreateLabelFromShipmentDetails/Result.cs
@@ -161,7 +161,7 @@ namespace ShipEngineSDK.CreateLabelFromShipmentDetails
         /// <summary>
         /// The label's package(s).
         /// </summary>
-        public List<LabelPackage> Packages { get; set; }
+        public List<LabelPackage>? Packages { get; set; }
     }
 
     /// <summary>

--- a/ShipEngine/Models/Dto/GetRatesFromShipmentDetails/Params.cs
+++ b/ShipEngine/Models/Dto/GetRatesFromShipmentDetails/Params.cs
@@ -145,6 +145,9 @@ namespace ShipEngineSDK.GetRatesWithShipmentDetails
         /// </summary>
         public Weight Weight { get; set; }
 
+        /// <summary>
+        /// The type of comparison rate
+        /// </summary>
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public ComparisonRateType? ComparisonRateType { get; set; }
 

--- a/ShipEngine/Models/Dto/GetRatesFromShipmentDetails/Result.cs
+++ b/ShipEngine/Models/Dto/GetRatesFromShipmentDetails/Result.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 
 namespace ShipEngineSDK.GetRatesWithShipmentDetails
 {
+    /// <summary>
+    /// Get rates with shipment details result
+    /// </summary>
     public class Result
     {
         /// <summary>
@@ -29,12 +32,12 @@ namespace ShipEngineSDK.GetRatesWithShipmentDetails
         /// <summary>
         /// Describe the packages included in this shipment as related to potential metadata that was imported from external order sources
         /// </summary>
-        public List<ShipmentItem> Items { get; set; }
+        public List<ShipmentItem>? Items { get; set; }
 
         /// <summary>
         /// Tax identifiers
         /// </summary>
-        public List<TaxIdentifier> TaxIdentifiers { get; set; }
+        public List<TaxIdentifier>? TaxIdentifiers { get; set; }
 
         /// <summary>
         /// You can optionally use this field to store your own identifier for this shipment.
@@ -64,13 +67,13 @@ namespace ShipEngineSDK.GetRatesWithShipmentDetails
         /// <summary>
         /// The recipient's mailing address
         /// </summary>
-        public Address ShipTo { get; set; }
+        public Address? ShipTo { get; set; }
 
         /// <summary>
         /// The shipment's origin address. If you frequently ship from the same location, consider creating a warehouse.
         /// Then you can simply specify the warehouse_id rather than the complete address each time.
         /// </summary>
-        public Address ShipFrom { get; set; }
+        public Address? ShipFrom { get; set; }
 
         /// <summary>
         /// The warehouse that the shipment is being shipped from. Either warehouse_id or ship_from must be specified.
@@ -80,7 +83,7 @@ namespace ShipEngineSDK.GetRatesWithShipmentDetails
         /// <summary>
         /// The return address for this shipment. Defaults to the ship_from address.
         /// </summary>
-        public Address ReturnTo { get; set; }
+        public Address? ReturnTo { get; set; }
 
         /// <summary>
         /// The type of delivery confirmation that is required for this shipment.
@@ -90,12 +93,12 @@ namespace ShipEngineSDK.GetRatesWithShipmentDetails
         /// <summary>
         /// Customs information. This is usually only needed for international shipments.
         /// </summary>
-        public Customs Customs { get; set; }
+        public Customs? Customs { get; set; }
 
         /// <summary>
         /// Advanced shipment options. These are entirely optional.
         /// </summary>
-        public AdvancedShipmentOptions AdvancedOptions { get; set; }
+        public AdvancedShipmentOptions? AdvancedOptions { get; set; }
 
         /// <summary>
         /// Indicates if the package will be picked up or dropped off by the carrier
@@ -110,13 +113,13 @@ namespace ShipEngineSDK.GetRatesWithShipmentDetails
         /// <summary>
         /// Arbitrary tags associated with this shipment. Tags can be used to categorize shipments, and shipments can be queried by their tags.
         /// </summary>
-        public List<string> Tags { get; set; }
+        public List<string>? Tags { get; set; }
 
 
         /// <summary>
         /// Total Weight of the Shipment
         /// </summary>
-        public Weight TotalWeight { get; set; }
+        public Weight? TotalWeight { get; set; }
 
         /// <summary>
         /// The order sources that are supported by ShipEngine
@@ -126,30 +129,33 @@ namespace ShipEngineSDK.GetRatesWithShipmentDetails
         /// <summary>
         /// The packages in the shipment.
         /// </summary>
-        public List<ShipmentPackage> Packages { get; set; }
+        public List<ShipmentPackage>? Packages { get; set; }
 
         /// <summary>
         /// The combined weight of all packages in the shipment
         /// </summary>
-        public Weight Weight { get; set; }
+        public Weight? Weight { get; set; }
 
         /// <summary>
         /// The rate responses
         /// </summary>
-        public RateResponse RateResponse { get; set; }
+        public RateResponse? RateResponse { get; set; }
     }
 
+    /// <summary>
+    /// The get rates with shipment details rate response
+    /// </summary>
     public class RateResponse
     {
         /// <summary>
         /// A list of shipment rates
         /// </summary>
-        public List<Rate> Rates { get; set; }
+        public List<Rate>? Rates { get; set; }
 
         /// <summary>
         /// A list of invalid shipment rates
         /// </summary>
-        public List<Rate> InvalidRates { get; set; }
+        public List<Rate>? InvalidRates { get; set; }
 
         /// <summary>
         /// A string that uniquely identifies the rate request
@@ -174,9 +180,12 @@ namespace ShipEngineSDK.GetRatesWithShipmentDetails
         /// <summary>
         /// Any errors associated with the rate request
         /// </summary>
-        public List<ShipEngineException> Errors { get; set; }
+        public List<ShipEngineException>? Errors { get; set; }
     }
 
+    /// <summary>
+    /// The individual rate
+    /// </summary>
     public class Rate
     {
         /// <summary>
@@ -197,33 +206,31 @@ namespace ShipEngineSDK.GetRatesWithShipmentDetails
         /// <summary>
         /// The shipping amount
         /// </summary>
-        public MonetaryValue ShippingAmount { get; set; }
+        public MonetaryValue? ShippingAmount { get; set; }
 
         /// <summary>
         /// The insurance amount
         /// </summary>
-        public MonetaryValue InsuranceAmount { get; set; }
+        public MonetaryValue? InsuranceAmount { get; set; }
 
         /// <summary>
         /// The sum of the carrier costs for the shipment
         /// </summary>
-        public MonetaryValue RequestedComparisonAmount { get; set; }
-
-
+        public MonetaryValue? RequestedComparisonAmount { get; set; }
 
         /// <summary>
         /// The confirmation amount
         /// </summary>
-        public MonetaryValue ConfirmationAmount { get; set; }
+        public MonetaryValue? ConfirmationAmount { get; set; }
 
         /// <summary>
         /// Any other charges associated with this rate
         /// </summary>
-        public MonetaryValue OtherAmount { get; set; }
+        public MonetaryValue? OtherAmount { get; set; }
         /// <summary>
         /// Tariff and additional taxes associated with an international shipment.
         /// </summary>
-        public MonetaryValue TaxAmount { get; set; }
+        public MonetaryValue? TaxAmount { get; set; }
 
         /// <summary>
         /// Certain carriers base their rates off of custom zones that vary depending upon
@@ -306,11 +313,11 @@ namespace ShipEngineSDK.GetRatesWithShipmentDetails
         /// <summary>
         /// The warning messages
         /// </summary>
-        public List<string> WarningMessages { get; set; }
+        public List<string>? WarningMessages { get; set; }
 
         /// <summary>
         /// The error messages
         /// </summary>
-        public List<string> ErrorMessages { get; set; }
+        public List<string>? ErrorMessages { get; set; }
     }
 }

--- a/ShipEngine/Models/Dto/VoidLabelWithLabelId/Result.cs
+++ b/ShipEngine/Models/Dto/VoidLabelWithLabelId/Result.cs
@@ -13,6 +13,6 @@ namespace ShipEngineSDK.VoidLabelWithLabelId
         /// <summary>
         /// Message associated with the result of the void label attempt
         /// </summary>
-        public string Message { get; set; }
+        public string? Message { get; set; }
     }
 }

--- a/ShipEngine/Models/ShipEngineException.cs
+++ b/ShipEngine/Models/ShipEngineException.cs
@@ -38,7 +38,7 @@ namespace ShipEngineSDK
             ErrorSource errorSource = ErrorSource.Shipengine,
             ErrorType errorType = ErrorType.System,
             ErrorCode errorCode = ErrorCode.Unspecified,
-            string requestID = null) : base(message)
+            string? requestID = null) : base(message)
         {
             ErrorSource = errorSource;
             ErrorType = errorType;

--- a/ShipEngine/Models/ShipEngineException.cs
+++ b/ShipEngine/Models/ShipEngineException.cs
@@ -1,49 +1,48 @@
 #pragma warning disable 1591
 
 using System;
+using System.Net.Http;
 
 namespace ShipEngineSDK
 {
     /// <summary>
     /// Error object returned from failed method calls
     /// </summary>
-    public class ShipEngineException : Exception
+    public class ShipEngineException(
+        string message,
+        ErrorSource errorSource = ErrorSource.Shipengine,
+        ErrorType errorType = ErrorType.System,
+        ErrorCode errorCode = ErrorCode.Unspecified,
+        HttpResponseMessage? responseMessage = null,
+        string? requestID = null)
+        : Exception(message)
     {
         /// <summary>
         /// A UUID that uniquely identifies the request id.
         /// This can be given to the support team to help debug non-trivial issues that may occur
         /// </summary>
 
-        public string? RequestId { get; }
+        public string? RequestId { get; } = requestID;
 
         /// <summary>
         /// The source of the error, as indicated by the name this informs us if the API call failed
         /// because of the carrier, the order source, or the ShipEngine API itself.
         /// </summary>
-        public ErrorSource ErrorSource { get; set; }
+        public ErrorSource ErrorSource { get; set; } = errorSource;
 
         /// <summary>
         /// The type of error
         /// </summary>
-        public ErrorType ErrorType { get; set; }
+        public ErrorType ErrorType { get; set; } = errorType;
 
         /// <summary>
         /// The error code specified for the failed API Call
         /// </summary>
-        public ErrorCode ErrorCode { get; set; }
+        public ErrorCode ErrorCode { get; set; } = errorCode;
 
-
-        public ShipEngineException(
-            string message,
-            ErrorSource errorSource = ErrorSource.Shipengine,
-            ErrorType errorType = ErrorType.System,
-            ErrorCode errorCode = ErrorCode.Unspecified,
-            string? requestID = null) : base(message)
-        {
-            ErrorSource = errorSource;
-            ErrorType = errorType;
-            ErrorCode = errorCode;
-            RequestId = requestID;
-        }
+        /// <summary>
+        /// The http response message returned from the failed API call
+        /// </summary>
+        public HttpResponseMessage? ResponseMessage { get; set; } = responseMessage;
     }
 }

--- a/ShipEngine/PublicAPI.Shipped.txt
+++ b/ShipEngine/PublicAPI.Shipped.txt
@@ -1048,6 +1048,25 @@ ShipEngineSDK.GetRatesWithShipmentDetails.ValidationStatus.HasWarnings = 2 -> Sh
 ShipEngineSDK.GetRatesWithShipmentDetails.ValidationStatus.Invalid = 1 -> ShipEngineSDK.GetRatesWithShipmentDetails.ValidationStatus
 ShipEngineSDK.GetRatesWithShipmentDetails.ValidationStatus.Unknown = 3 -> ShipEngineSDK.GetRatesWithShipmentDetails.ValidationStatus
 ShipEngineSDK.GetRatesWithShipmentDetails.ValidationStatus.Valid = 0 -> ShipEngineSDK.GetRatesWithShipmentDetails.ValidationStatus
+ShipEngineSDK.IShipEngine
+ShipEngineSDK.IShipEngine.CreateLabelFromRate(ShipEngineSDK.CreateLabelFromRate.Params! createLabelFromRateParams) -> System.Threading.Tasks.Task<ShipEngineSDK.CreateLabelFromRate.Result!>!
+ShipEngineSDK.IShipEngine.CreateLabelFromRate(ShipEngineSDK.CreateLabelFromRate.Params! createLabelFromRateParams, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.CreateLabelFromRate.Result!>!
+ShipEngineSDK.IShipEngine.CreateLabelFromShipmentDetails(ShipEngineSDK.CreateLabelFromShipmentDetails.Params! labelParams) -> System.Threading.Tasks.Task<ShipEngineSDK.CreateLabelFromShipmentDetails.Result!>!
+ShipEngineSDK.IShipEngine.CreateLabelFromShipmentDetails(ShipEngineSDK.CreateLabelFromShipmentDetails.Params! labelParams, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.CreateLabelFromShipmentDetails.Result!>!
+ShipEngineSDK.IShipEngine.CreateManifest(ShipEngineSDK.Config! methodConfig, ShipEngineSDK.Manifests.Params! manifestParams) -> System.Threading.Tasks.Task<ShipEngineSDK.Manifests.Result!>!
+ShipEngineSDK.IShipEngine.CreateManifest(ShipEngineSDK.Manifests.Params! manifestParams) -> System.Threading.Tasks.Task<ShipEngineSDK.Manifests.Result!>!
+ShipEngineSDK.IShipEngine.GetRatesWithShipmentDetails(ShipEngineSDK.GetRatesWithShipmentDetails.Params! rateParams) -> System.Threading.Tasks.Task<ShipEngineSDK.GetRatesWithShipmentDetails.Result!>!
+ShipEngineSDK.IShipEngine.GetRatesWithShipmentDetails(ShipEngineSDK.GetRatesWithShipmentDetails.Params! rateParams, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.GetRatesWithShipmentDetails.Result!>!
+ShipEngineSDK.IShipEngine.ListCarriers() -> System.Threading.Tasks.Task<ShipEngineSDK.ListCarriers.Result!>!
+ShipEngineSDK.IShipEngine.ListCarriers(ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.ListCarriers.Result!>!
+ShipEngineSDK.IShipEngine.TrackUsingCarrierCodeAndTrackingNumber(string! trackingNumber, string! carrierCode) -> System.Threading.Tasks.Task<ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result!>!
+ShipEngineSDK.IShipEngine.TrackUsingCarrierCodeAndTrackingNumber(string! trackingNumber, string! carrierCode, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result!>!
+ShipEngineSDK.IShipEngine.TrackUsingLabelId(string! labelId) -> System.Threading.Tasks.Task<ShipEngineSDK.TrackUsingLabelId.Result!>!
+ShipEngineSDK.IShipEngine.TrackUsingLabelId(string! labelId, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.TrackUsingLabelId.Result!>!
+ShipEngineSDK.IShipEngine.ValidateAddresses(System.Collections.Generic.List<ShipEngineSDK.Common.Address!>! addresses) -> System.Threading.Tasks.Task<System.Collections.Generic.List<ShipEngineSDK.ValidateAddresses.Result!>!>!
+ShipEngineSDK.IShipEngine.ValidateAddresses(System.Collections.Generic.List<ShipEngineSDK.Common.Address!>! addresses, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<System.Collections.Generic.List<ShipEngineSDK.ValidateAddresses.Result!>!>!
+ShipEngineSDK.IShipEngine.VoidLabelWithLabelId(string! labelId) -> System.Threading.Tasks.Task<ShipEngineSDK.VoidLabelWithLabelId.Result!>!
+ShipEngineSDK.IShipEngine.VoidLabelWithLabelId(string! labelId, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.VoidLabelWithLabelId.Result!>!
 ShipEngineSDK.ListCarriers.AdvancedOption
 ShipEngineSDK.ListCarriers.AdvancedOption.AdvancedOption() -> void
 ShipEngineSDK.ListCarriers.Carrier
@@ -1188,6 +1207,8 @@ ShipEngineSDK.ShipEngineException.ResponseMessage.get -> System.Net.Http.HttpRes
 ShipEngineSDK.ShipEngineException.ResponseMessage.set -> void
 ShipEngineSDK.ShipEngineException.ShipEngineException(string! message, ShipEngineSDK.ErrorSource errorSource = ShipEngineSDK.ErrorSource.Shipengine, ShipEngineSDK.ErrorType errorType = ShipEngineSDK.ErrorType.System, ShipEngineSDK.ErrorCode errorCode = ShipEngineSDK.ErrorCode.Unspecified, System.Net.Http.HttpResponseMessage? responseMessage = null, string? requestID = null) -> void
 ShipEngineSDK.ShipEngineExtensions
+ShipEngineSDK.ShipEngineMock
+ShipEngineSDK.ShipEngineMock.ShipEngineMock() -> void
 ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result
 ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result.Result() -> void
 ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result.StatusCode.get -> ShipEngineSDK.Common.Enums.TrackingStatusCode
@@ -1301,6 +1322,24 @@ static ShipEngineSDK.ShipEngineClient.ConfigureHttpClient(ShipEngineSDK.Config! 
 static ShipEngineSDK.ShipEngineClient.ConfigureHttpClient(System.Net.Http.HttpClient! client, string! apiKey, System.Uri? baseUri, System.TimeSpan? timeout = null) -> System.Net.Http.HttpClient!
 static ShipEngineSDK.ShipEngineExtensions.AddShipEngine(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, System.Action<System.Net.Http.HttpClient!>? configureClient = null) -> Microsoft.Extensions.Hosting.IHostApplicationBuilder!
 virtual ShipEngineSDK.ShipEngineClient.SendHttpRequestAsync<T>(System.Net.Http.HttpMethod! method, string! path, string? jsonContent, System.Net.Http.HttpClient! client, ShipEngineSDK.Config! config) -> System.Threading.Tasks.Task<T>!
+virtual ShipEngineSDK.ShipEngineMock.CreateLabelFromRate(ShipEngineSDK.CreateLabelFromRate.Params! createLabelFromRateParams) -> System.Threading.Tasks.Task<ShipEngineSDK.CreateLabelFromRate.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.CreateLabelFromRate(ShipEngineSDK.CreateLabelFromRate.Params! createLabelFromRateParams, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.CreateLabelFromRate.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.CreateLabelFromShipmentDetails(ShipEngineSDK.CreateLabelFromShipmentDetails.Params! labelParams) -> System.Threading.Tasks.Task<ShipEngineSDK.CreateLabelFromShipmentDetails.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.CreateLabelFromShipmentDetails(ShipEngineSDK.CreateLabelFromShipmentDetails.Params! labelParams, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.CreateLabelFromShipmentDetails.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.CreateManifest(ShipEngineSDK.Config! methodConfig, ShipEngineSDK.Manifests.Params! manifestParams) -> System.Threading.Tasks.Task<ShipEngineSDK.Manifests.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.CreateManifest(ShipEngineSDK.Manifests.Params! manifestParams) -> System.Threading.Tasks.Task<ShipEngineSDK.Manifests.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.GetRatesWithShipmentDetails(ShipEngineSDK.GetRatesWithShipmentDetails.Params! rateParams) -> System.Threading.Tasks.Task<ShipEngineSDK.GetRatesWithShipmentDetails.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.GetRatesWithShipmentDetails(ShipEngineSDK.GetRatesWithShipmentDetails.Params! rateParams, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.GetRatesWithShipmentDetails.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.ListCarriers() -> System.Threading.Tasks.Task<ShipEngineSDK.ListCarriers.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.ListCarriers(ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.ListCarriers.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.TrackUsingCarrierCodeAndTrackingNumber(string! trackingNumber, string! carrierCode) -> System.Threading.Tasks.Task<ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.TrackUsingCarrierCodeAndTrackingNumber(string! trackingNumber, string! carrierCode, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.TrackUsingLabelId(string! labelId) -> System.Threading.Tasks.Task<ShipEngineSDK.TrackUsingLabelId.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.TrackUsingLabelId(string! labelId, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.TrackUsingLabelId.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.ValidateAddresses(System.Collections.Generic.List<ShipEngineSDK.Common.Address!>! addresses) -> System.Threading.Tasks.Task<System.Collections.Generic.List<ShipEngineSDK.ValidateAddresses.Result!>!>!
+virtual ShipEngineSDK.ShipEngineMock.ValidateAddresses(System.Collections.Generic.List<ShipEngineSDK.Common.Address!>! addresses, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<System.Collections.Generic.List<ShipEngineSDK.ValidateAddresses.Result!>!>!
+virtual ShipEngineSDK.ShipEngineMock.VoidLabelWithLabelId(string! labelId) -> System.Threading.Tasks.Task<ShipEngineSDK.VoidLabelWithLabelId.Result!>!
+virtual ShipEngineSDK.ShipEngineMock.VoidLabelWithLabelId(string! labelId, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.VoidLabelWithLabelId.Result!>!
 ~ShipEngineSDK.Common.Error.Message.get -> string
 ~ShipEngineSDK.Common.Error.Message.set -> void
 ~ShipEngineSDK.Common.ShipEngineAPIError.Errors.get -> System.Collections.Generic.List<ShipEngineSDK.Common.Error>

--- a/ShipEngine/PublicAPI.Shipped.txt
+++ b/ShipEngine/PublicAPI.Shipped.txt
@@ -1178,7 +1178,9 @@ ShipEngineSDK.ShipEngineException.ErrorSource.set -> void
 ShipEngineSDK.ShipEngineException.ErrorType.get -> ShipEngineSDK.ErrorType
 ShipEngineSDK.ShipEngineException.ErrorType.set -> void
 ShipEngineSDK.ShipEngineException.RequestId.get -> string?
-ShipEngineSDK.ShipEngineException.ShipEngineException(string! message, ShipEngineSDK.ErrorSource errorSource = ShipEngineSDK.ErrorSource.Shipengine, ShipEngineSDK.ErrorType errorType = ShipEngineSDK.ErrorType.System, ShipEngineSDK.ErrorCode errorCode = ShipEngineSDK.ErrorCode.Unspecified, string? requestID = null) -> void
+ShipEngineSDK.ShipEngineException.ResponseMessage.get -> System.Net.Http.HttpResponseMessage?
+ShipEngineSDK.ShipEngineException.ResponseMessage.set -> void
+ShipEngineSDK.ShipEngineException.ShipEngineException(string! message, ShipEngineSDK.ErrorSource errorSource = ShipEngineSDK.ErrorSource.Shipengine, ShipEngineSDK.ErrorType errorType = ShipEngineSDK.ErrorType.System, ShipEngineSDK.ErrorCode errorCode = ShipEngineSDK.ErrorCode.Unspecified, System.Net.Http.HttpResponseMessage? responseMessage = null, string? requestID = null) -> void
 ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result
 ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result.Result() -> void
 ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result.StatusCode.get -> ShipEngineSDK.Common.Enums.TrackingStatusCode

--- a/ShipEngine/PublicAPI.Shipped.txt
+++ b/ShipEngine/PublicAPI.Shipped.txt
@@ -1,11 +1,10 @@
 ﻿#nullable enable
-override ShipEngineSDK.Common.MonetaryValueConverter.CanWrite.get -> bool
-override ShipEngineSDK.Common.MonetaryValueConverter.ReadJson(Newtonsoft.Json.JsonReader! reader, System.Type! objectType, ShipEngineSDK.Common.MonetaryValue! existingValue, bool hasExistingValue, Newtonsoft.Json.JsonSerializer! serializer) -> ShipEngineSDK.Common.MonetaryValue!
-override ShipEngineSDK.Common.MonetaryValueConverter.WriteJson(Newtonsoft.Json.JsonWriter! writer, ShipEngineSDK.Common.MonetaryValue! value, Newtonsoft.Json.JsonSerializer! serializer) -> void
+override ShipEngineSDK.Common.MonetaryValueConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! type, System.Text.Json.JsonSerializerOptions! options) -> ShipEngineSDK.Common.MonetaryValue!
+override ShipEngineSDK.Common.MonetaryValueConverter.Write(System.Text.Json.Utf8JsonWriter! writer, ShipEngineSDK.Common.MonetaryValue! value, System.Text.Json.JsonSerializerOptions! options) -> void
 readonly ShipEngineSDK.Config.ApiKey -> string!
 readonly ShipEngineSDK.Config.Retries -> int
 readonly ShipEngineSDK.Config.Timeout -> System.TimeSpan
-readonly ShipEngineSDK.ShipEngineClient.JsonSerializerSettings -> Newtonsoft.Json.JsonSerializerSettings!
+readonly ShipEngineSDK.ShipEngineClient.JsonSerializerOptions -> System.Text.Json.JsonSerializerOptions!
 ShipEngineSDK.Common.Address
 ShipEngineSDK.Common.Address.Address() -> void
 ShipEngineSDK.Common.Address.AddressLine1.get -> string?
@@ -80,7 +79,7 @@ ShipEngineSDK.Common.Customs
 ShipEngineSDK.Common.Customs.Contents.get -> ShipEngineSDK.Common.Enums.PackageContents
 ShipEngineSDK.Common.Customs.Contents.set -> void
 ShipEngineSDK.Common.Customs.Customs() -> void
-ShipEngineSDK.Common.Customs.CustomsItems.get -> System.Collections.Generic.List<ShipEngineSDK.Common.CustomsItem!>!
+ShipEngineSDK.Common.Customs.CustomsItems.get -> System.Collections.Generic.List<ShipEngineSDK.Common.CustomsItem!>?
 ShipEngineSDK.Common.Customs.CustomsItems.set -> void
 ShipEngineSDK.Common.Customs.NonDelivery.get -> ShipEngineSDK.Common.Enums.NonDelivery
 ShipEngineSDK.Common.Customs.NonDelivery.set -> void
@@ -657,7 +656,7 @@ ShipEngineSDK.CreateLabelFromRate.Result.LabelLayout.get -> ShipEngineSDK.Common
 ShipEngineSDK.CreateLabelFromRate.Result.LabelLayout.set -> void
 ShipEngineSDK.CreateLabelFromRate.Result.PackageCode.get -> string?
 ShipEngineSDK.CreateLabelFromRate.Result.PackageCode.set -> void
-ShipEngineSDK.CreateLabelFromRate.Result.Packages.get -> System.Collections.Generic.List<ShipEngineSDK.CreateLabelFromRate.Package!>!
+ShipEngineSDK.CreateLabelFromRate.Result.Packages.get -> System.Collections.Generic.List<ShipEngineSDK.CreateLabelFromRate.Package!>?
 ShipEngineSDK.CreateLabelFromRate.Result.Packages.set -> void
 ShipEngineSDK.CreateLabelFromRate.Result.Result() -> void
 ShipEngineSDK.CreateLabelFromRate.Result.RmaNumber.get -> string?
@@ -794,7 +793,7 @@ ShipEngineSDK.CreateLabelFromShipmentDetails.Result.LabelLayout.get -> ShipEngin
 ShipEngineSDK.CreateLabelFromShipmentDetails.Result.LabelLayout.set -> void
 ShipEngineSDK.CreateLabelFromShipmentDetails.Result.PackageCode.get -> string?
 ShipEngineSDK.CreateLabelFromShipmentDetails.Result.PackageCode.set -> void
-ShipEngineSDK.CreateLabelFromShipmentDetails.Result.Packages.get -> System.Collections.Generic.List<ShipEngineSDK.CreateLabelFromShipmentDetails.LabelPackage!>!
+ShipEngineSDK.CreateLabelFromShipmentDetails.Result.Packages.get -> System.Collections.Generic.List<ShipEngineSDK.CreateLabelFromShipmentDetails.LabelPackage!>?
 ShipEngineSDK.CreateLabelFromShipmentDetails.Result.Packages.set -> void
 ShipEngineSDK.CreateLabelFromShipmentDetails.Result.Result() -> void
 ShipEngineSDK.CreateLabelFromShipmentDetails.Result.RmaNumber.get -> string?
@@ -899,21 +898,21 @@ ShipEngineSDK.GetRatesWithShipmentDetails.Rate.CarrierId.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.CarrierId.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.CarrierNickname.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.CarrierNickname.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ConfirmationAmount.get -> ShipEngineSDK.Common.MonetaryValue!
+ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ConfirmationAmount.get -> ShipEngineSDK.Common.MonetaryValue?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ConfirmationAmount.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.DeliveryDays.get -> int?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.DeliveryDays.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ErrorMessages.get -> System.Collections.Generic.List<string!>!
+ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ErrorMessages.get -> System.Collections.Generic.List<string!>?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ErrorMessages.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.EstimatedDeliveryDate.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.EstimatedDeliveryDate.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.GuaranteedService.get -> bool
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.GuaranteedService.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Rate.InsuranceAmount.get -> ShipEngineSDK.Common.MonetaryValue!
+ShipEngineSDK.GetRatesWithShipmentDetails.Rate.InsuranceAmount.get -> ShipEngineSDK.Common.MonetaryValue?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.InsuranceAmount.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.NegotiatedRate.get -> bool
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.NegotiatedRate.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Rate.OtherAmount.get -> ShipEngineSDK.Common.MonetaryValue!
+ShipEngineSDK.GetRatesWithShipmentDetails.Rate.OtherAmount.get -> ShipEngineSDK.Common.MonetaryValue?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.OtherAmount.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.PackageType.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.PackageType.set -> void
@@ -922,7 +921,7 @@ ShipEngineSDK.GetRatesWithShipmentDetails.Rate.RateId.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.RateId.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.RateType.get -> ShipEngineSDK.GetRatesWithShipmentDetails.RateType
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.RateType.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Rate.RequestedComparisonAmount.get -> ShipEngineSDK.Common.MonetaryValue!
+ShipEngineSDK.GetRatesWithShipmentDetails.Rate.RequestedComparisonAmount.get -> ShipEngineSDK.Common.MonetaryValue?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.RequestedComparisonAmount.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ServiceCode.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ServiceCode.set -> void
@@ -930,15 +929,15 @@ ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ServiceType.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ServiceType.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ShipDate.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ShipDate.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ShippingAmount.get -> ShipEngineSDK.Common.MonetaryValue!
+ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ShippingAmount.get -> ShipEngineSDK.Common.MonetaryValue?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ShippingAmount.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Rate.TaxAmount.get -> ShipEngineSDK.Common.MonetaryValue!
+ShipEngineSDK.GetRatesWithShipmentDetails.Rate.TaxAmount.get -> ShipEngineSDK.Common.MonetaryValue?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.TaxAmount.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.Trackable.get -> bool
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.Trackable.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ValidationStatus.get -> ShipEngineSDK.GetRatesWithShipmentDetails.ValidationStatus
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.ValidationStatus.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Rate.WarningMessages.get -> System.Collections.Generic.List<string!>!
+ShipEngineSDK.GetRatesWithShipmentDetails.Rate.WarningMessages.get -> System.Collections.Generic.List<string!>?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.WarningMessages.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.Zone.get -> int?
 ShipEngineSDK.GetRatesWithShipmentDetails.Rate.Zone.set -> void
@@ -951,14 +950,14 @@ ShipEngineSDK.GetRatesWithShipmentDetails.RateOptions.RateOptions() -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse
 ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.CreatedAt.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.CreatedAt.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.Errors.get -> System.Collections.Generic.List<ShipEngineSDK.ShipEngineException!>!
+ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.Errors.get -> System.Collections.Generic.List<ShipEngineSDK.ShipEngineException!>?
 ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.Errors.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.InvalidRates.get -> System.Collections.Generic.List<ShipEngineSDK.GetRatesWithShipmentDetails.Rate!>!
+ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.InvalidRates.get -> System.Collections.Generic.List<ShipEngineSDK.GetRatesWithShipmentDetails.Rate!>?
 ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.InvalidRates.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.RateRequestId.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.RateRequestId.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.RateResponse() -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.Rates.get -> System.Collections.Generic.List<ShipEngineSDK.GetRatesWithShipmentDetails.Rate!>!
+ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.Rates.get -> System.Collections.Generic.List<ShipEngineSDK.GetRatesWithShipmentDetails.Rate!>?
 ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.Rates.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.ShipmentId.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse.ShipmentId.set -> void
@@ -973,7 +972,7 @@ ShipEngineSDK.GetRatesWithShipmentDetails.RateType
 ShipEngineSDK.GetRatesWithShipmentDetails.RateType.Check = 0 -> ShipEngineSDK.GetRatesWithShipmentDetails.RateType
 ShipEngineSDK.GetRatesWithShipmentDetails.RateType.Shipment = 1 -> ShipEngineSDK.GetRatesWithShipmentDetails.RateType
 ShipEngineSDK.GetRatesWithShipmentDetails.Result
-ShipEngineSDK.GetRatesWithShipmentDetails.Result.AdvancedOptions.get -> ShipEngineSDK.Common.AdvancedShipmentOptions!
+ShipEngineSDK.GetRatesWithShipmentDetails.Result.AdvancedOptions.get -> ShipEngineSDK.Common.AdvancedShipmentOptions?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.AdvancedOptions.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.CarrierId.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.CarrierId.set -> void
@@ -981,7 +980,7 @@ ShipEngineSDK.GetRatesWithShipmentDetails.Result.Confirmation.get -> ShipEngineS
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.Confirmation.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.CreatedAt.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.CreatedAt.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Result.Customs.get -> ShipEngineSDK.Common.Customs!
+ShipEngineSDK.GetRatesWithShipmentDetails.Result.Customs.get -> ShipEngineSDK.Common.Customs?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.Customs.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ExternalOrderId.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ExternalOrderId.set -> void
@@ -989,7 +988,7 @@ ShipEngineSDK.GetRatesWithShipmentDetails.Result.ExternalShipmentId.get -> strin
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ExternalShipmentId.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.InsuranceProvider.get -> ShipEngineSDK.Common.Enums.InsuranceProvider
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.InsuranceProvider.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Result.Items.get -> System.Collections.Generic.List<ShipEngineSDK.Common.ShipmentItem!>!
+ShipEngineSDK.GetRatesWithShipmentDetails.Result.Items.get -> System.Collections.Generic.List<ShipEngineSDK.Common.ShipmentItem!>?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.Items.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ModifiedAt.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ModifiedAt.set -> void
@@ -997,34 +996,34 @@ ShipEngineSDK.GetRatesWithShipmentDetails.Result.OrderSourceCode.get -> ShipEngi
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.OrderSourceCode.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.OriginType.get -> ShipEngineSDK.Common.Enums.OriginType
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.OriginType.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Result.Packages.get -> System.Collections.Generic.List<ShipEngineSDK.Common.ShipmentPackage!>!
+ShipEngineSDK.GetRatesWithShipmentDetails.Result.Packages.get -> System.Collections.Generic.List<ShipEngineSDK.Common.ShipmentPackage!>?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.Packages.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Result.RateResponse.get -> ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse!
+ShipEngineSDK.GetRatesWithShipmentDetails.Result.RateResponse.get -> ShipEngineSDK.GetRatesWithShipmentDetails.RateResponse?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.RateResponse.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.Result() -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Result.ReturnTo.get -> ShipEngineSDK.Common.Address!
+ShipEngineSDK.GetRatesWithShipmentDetails.Result.ReturnTo.get -> ShipEngineSDK.Common.Address?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ReturnTo.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ServiceCode.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ServiceCode.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ShipDate.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ShipDate.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Result.ShipFrom.get -> ShipEngineSDK.Common.Address!
+ShipEngineSDK.GetRatesWithShipmentDetails.Result.ShipFrom.get -> ShipEngineSDK.Common.Address?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ShipFrom.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ShipmentId.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ShipmentId.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ShipmentStatus.get -> ShipEngineSDK.GetRatesWithShipmentDetails.ShipmentStatus
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ShipmentStatus.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Result.ShipTo.get -> ShipEngineSDK.Common.Address!
+ShipEngineSDK.GetRatesWithShipmentDetails.Result.ShipTo.get -> ShipEngineSDK.Common.Address?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.ShipTo.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Result.Tags.get -> System.Collections.Generic.List<string!>!
+ShipEngineSDK.GetRatesWithShipmentDetails.Result.Tags.get -> System.Collections.Generic.List<string!>?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.Tags.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Result.TaxIdentifiers.get -> System.Collections.Generic.List<ShipEngineSDK.Common.TaxIdentifier!>!
+ShipEngineSDK.GetRatesWithShipmentDetails.Result.TaxIdentifiers.get -> System.Collections.Generic.List<ShipEngineSDK.Common.TaxIdentifier!>?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.TaxIdentifiers.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Result.TotalWeight.get -> ShipEngineSDK.Common.Weight!
+ShipEngineSDK.GetRatesWithShipmentDetails.Result.TotalWeight.get -> ShipEngineSDK.Common.Weight?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.TotalWeight.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.WarehouseId.get -> string?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.WarehouseId.set -> void
-ShipEngineSDK.GetRatesWithShipmentDetails.Result.Weight.get -> ShipEngineSDK.Common.Weight!
+ShipEngineSDK.GetRatesWithShipmentDetails.Result.Weight.get -> ShipEngineSDK.Common.Weight?
 ShipEngineSDK.GetRatesWithShipmentDetails.Result.Weight.set -> void
 ShipEngineSDK.GetRatesWithShipmentDetails.Shipment
 ShipEngineSDK.GetRatesWithShipmentDetails.Shipment.ComparisonRateType.get -> ShipEngineSDK.GetRatesWithShipmentDetails.ComparisonRateType?
@@ -1179,7 +1178,7 @@ ShipEngineSDK.ShipEngineException.ErrorSource.set -> void
 ShipEngineSDK.ShipEngineException.ErrorType.get -> ShipEngineSDK.ErrorType
 ShipEngineSDK.ShipEngineException.ErrorType.set -> void
 ShipEngineSDK.ShipEngineException.RequestId.get -> string?
-ShipEngineSDK.ShipEngineException.ShipEngineException(string! message, ShipEngineSDK.ErrorSource errorSource = ShipEngineSDK.ErrorSource.Shipengine, ShipEngineSDK.ErrorType errorType = ShipEngineSDK.ErrorType.System, ShipEngineSDK.ErrorCode errorCode = ShipEngineSDK.ErrorCode.Unspecified, string! requestID = null) -> void
+ShipEngineSDK.ShipEngineException.ShipEngineException(string! message, ShipEngineSDK.ErrorSource errorSource = ShipEngineSDK.ErrorSource.Shipengine, ShipEngineSDK.ErrorType errorType = ShipEngineSDK.ErrorType.System, ShipEngineSDK.ErrorCode errorCode = ShipEngineSDK.ErrorCode.Unspecified, string? requestID = null) -> void
 ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result
 ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result.Result() -> void
 ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result.StatusCode.get -> ShipEngineSDK.Common.Enums.TrackingStatusCode
@@ -1285,7 +1284,7 @@ ShipEngineSDK.ValidateAddresses.ValidationMessageType.Warning = 1 -> ShipEngineS
 ShipEngineSDK.VoidLabelWithLabelId.Result
 ShipEngineSDK.VoidLabelWithLabelId.Result.Approved.get -> bool
 ShipEngineSDK.VoidLabelWithLabelId.Result.Approved.set -> void
-ShipEngineSDK.VoidLabelWithLabelId.Result.Message.get -> string!
+ShipEngineSDK.VoidLabelWithLabelId.Result.Message.get -> string?
 ShipEngineSDK.VoidLabelWithLabelId.Result.Message.set -> void
 ShipEngineSDK.VoidLabelWithLabelId.Result.Result() -> void
 static ShipEngineSDK.ShipEngineClient.ConfigureHttpClient(ShipEngineSDK.Config! config, System.Net.Http.HttpClient! client) -> System.Net.Http.HttpClient!

--- a/ShipEngine/PublicAPI.Shipped.txt
+++ b/ShipEngine/PublicAPI.Shipped.txt
@@ -4,7 +4,6 @@ override ShipEngineSDK.Common.MonetaryValueConverter.Write(System.Text.Json.Utf8
 readonly ShipEngineSDK.Config.ApiKey -> string!
 readonly ShipEngineSDK.Config.Retries -> int
 readonly ShipEngineSDK.Config.Timeout -> System.TimeSpan
-readonly ShipEngineSDK.ShipEngineClient.JsonSerializerOptions -> System.Text.Json.JsonSerializerOptions!
 ShipEngineSDK.Common.Address
 ShipEngineSDK.Common.Address.Address() -> void
 ShipEngineSDK.Common.Address.AddressLine1.get -> string?
@@ -1152,12 +1151,15 @@ ShipEngineSDK.ShipEngine.CreateLabelFromShipmentDetails(ShipEngineSDK.CreateLabe
 ShipEngineSDK.ShipEngine.CreateLabelFromShipmentDetails(ShipEngineSDK.CreateLabelFromShipmentDetails.Params! labelParams, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.CreateLabelFromShipmentDetails.Result!>!
 ShipEngineSDK.ShipEngine.CreateManifest(ShipEngineSDK.Config! methodConfig, ShipEngineSDK.Manifests.Params! manifestParams) -> System.Threading.Tasks.Task<ShipEngineSDK.Manifests.Result!>!
 ShipEngineSDK.ShipEngine.CreateManifest(ShipEngineSDK.Manifests.Params! manifestParams) -> System.Threading.Tasks.Task<ShipEngineSDK.Manifests.Result!>!
+ShipEngineSDK.ShipEngine.Dispose() -> void
 ShipEngineSDK.ShipEngine.GetRatesWithShipmentDetails(ShipEngineSDK.GetRatesWithShipmentDetails.Params! rateParams) -> System.Threading.Tasks.Task<ShipEngineSDK.GetRatesWithShipmentDetails.Result!>!
 ShipEngineSDK.ShipEngine.GetRatesWithShipmentDetails(ShipEngineSDK.GetRatesWithShipmentDetails.Params! rateParams, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.GetRatesWithShipmentDetails.Result!>!
 ShipEngineSDK.ShipEngine.ListCarriers() -> System.Threading.Tasks.Task<ShipEngineSDK.ListCarriers.Result!>!
 ShipEngineSDK.ShipEngine.ListCarriers(ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.ListCarriers.Result!>!
+ShipEngineSDK.ShipEngine.ModifyRequest(System.Action<System.Net.Http.HttpRequestMessage!>! modifyRequest) -> ShipEngineSDK.ShipEngine!
 ShipEngineSDK.ShipEngine.ShipEngine(ShipEngineSDK.Config! config) -> void
 ShipEngineSDK.ShipEngine.ShipEngine(string! apiKey) -> void
+ShipEngineSDK.ShipEngine.ShipEngine(System.Net.Http.HttpClient! httpClient) -> void
 ShipEngineSDK.ShipEngine.TrackUsingCarrierCodeAndTrackingNumber(string! trackingNumber, string! carrierCode) -> System.Threading.Tasks.Task<ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result!>!
 ShipEngineSDK.ShipEngine.TrackUsingCarrierCodeAndTrackingNumber(string! trackingNumber, string! carrierCode, ShipEngineSDK.Config! methodConfig) -> System.Threading.Tasks.Task<ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result!>!
 ShipEngineSDK.ShipEngine.TrackUsingLabelId(string! labelId) -> System.Threading.Tasks.Task<ShipEngineSDK.TrackUsingLabelId.Result!>!
@@ -1170,6 +1172,10 @@ ShipEngineSDK.ShipEngine._client -> System.Net.Http.HttpClient!
 ShipEngineSDK.ShipEngine._config -> ShipEngineSDK.Config!
 ShipEngineSDK.ShipEngineClient
 ShipEngineSDK.ShipEngineClient.ShipEngineClient() -> void
+ShipEngineSDK.ShipEngineClient.CancellationToken.get -> System.Threading.CancellationToken
+ShipEngineSDK.ShipEngineClient.CancellationToken.set -> void
+ShipEngineSDK.ShipEngineClient.ModifyRequest.get -> System.Action<System.Net.Http.HttpRequestMessage>
+ShipEngineSDK.ShipEngineClient.ModifyRequest.set -> void
 ShipEngineSDK.ShipEngineException
 ShipEngineSDK.ShipEngineException.ErrorCode.get -> ShipEngineSDK.ErrorCode
 ShipEngineSDK.ShipEngineException.ErrorCode.set -> void
@@ -1181,6 +1187,7 @@ ShipEngineSDK.ShipEngineException.RequestId.get -> string?
 ShipEngineSDK.ShipEngineException.ResponseMessage.get -> System.Net.Http.HttpResponseMessage?
 ShipEngineSDK.ShipEngineException.ResponseMessage.set -> void
 ShipEngineSDK.ShipEngineException.ShipEngineException(string! message, ShipEngineSDK.ErrorSource errorSource = ShipEngineSDK.ErrorSource.Shipengine, ShipEngineSDK.ErrorType errorType = ShipEngineSDK.ErrorType.System, ShipEngineSDK.ErrorCode errorCode = ShipEngineSDK.ErrorCode.Unspecified, System.Net.Http.HttpResponseMessage? responseMessage = null, string? requestID = null) -> void
+ShipEngineSDK.ShipEngineExtensions
 ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result
 ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result.Result() -> void
 ShipEngineSDK.TrackUsingCarrierCodeAndTrackingNumber.Result.StatusCode.get -> ShipEngineSDK.Common.Enums.TrackingStatusCode
@@ -1289,7 +1296,10 @@ ShipEngineSDK.VoidLabelWithLabelId.Result.Approved.set -> void
 ShipEngineSDK.VoidLabelWithLabelId.Result.Message.get -> string?
 ShipEngineSDK.VoidLabelWithLabelId.Result.Message.set -> void
 ShipEngineSDK.VoidLabelWithLabelId.Result.Result() -> void
+static readonly ShipEngineSDK.ShipEngineClient.JsonSerializerOptions -> System.Text.Json.JsonSerializerOptions!
 static ShipEngineSDK.ShipEngineClient.ConfigureHttpClient(ShipEngineSDK.Config! config, System.Net.Http.HttpClient! client) -> System.Net.Http.HttpClient!
+static ShipEngineSDK.ShipEngineClient.ConfigureHttpClient(System.Net.Http.HttpClient! client, string! apiKey, System.Uri? baseUri, System.TimeSpan? timeout = null) -> System.Net.Http.HttpClient!
+static ShipEngineSDK.ShipEngineExtensions.AddShipEngine(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, System.Action<System.Net.Http.HttpClient!>? configureClient = null) -> Microsoft.Extensions.Hosting.IHostApplicationBuilder!
 virtual ShipEngineSDK.ShipEngineClient.SendHttpRequestAsync<T>(System.Net.Http.HttpMethod! method, string! path, string? jsonContent, System.Net.Http.HttpClient! client, ShipEngineSDK.Config! config) -> System.Threading.Tasks.Task<T>!
 ~ShipEngineSDK.Common.Error.Message.get -> string
 ~ShipEngineSDK.Common.Error.Message.set -> void

--- a/ShipEngine/PublicAPI.Unshipped.txt
+++ b/ShipEngine/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
-﻿override ShipEngineSDK.Common.MonetaryValueConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! type, System.Text.Json.JsonSerializerOptions! options) -> ShipEngineSDK.Common.MonetaryValue!
-override ShipEngineSDK.Common.MonetaryValueConverter.Write(System.Text.Json.Utf8JsonWriter! writer, ShipEngineSDK.Common.MonetaryValue! value, System.Text.Json.JsonSerializerOptions! options) -> void
-readonly ShipEngineSDK.ShipEngineClient.JsonSerializerOptions -> System.Text.Json.JsonSerializerOptions!
+﻿

--- a/ShipEngine/ShipEngine.cs
+++ b/ShipEngine/ShipEngine.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ShipEngineSDK.Common;
+using ShipEngineSDK.Manifests;
+using Result = ShipEngineSDK.ValidateAddresses.Result;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -10,6 +12,342 @@ using System.Threading.Tasks;
 
 namespace ShipEngineSDK
 {
+    /// <summary>
+    /// Interface for ShipEngine
+    /// </summary>
+    public interface IShipEngine
+    {
+        /// <summary>
+        /// Validates an address in nearly any country in the world.
+        /// </summary>
+        /// <param name="addresses">The address to validate. This can even be an incomplete or improperly formatted address</param>
+        /// <returns>An address validation result object</returns>
+        Task<List<ValidateAddresses.Result>> ValidateAddresses(List<Address> addresses);
+
+        /// <summary>
+        /// Validates an address in nearly any country in the world.
+        /// </summary>
+        /// <param name="addresses">The address to validate. This can even be an incomplete or improperly formatted address</param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call</param>
+        /// <returns>An address validation result object</returns>
+        Task<List<ValidateAddresses.Result>> ValidateAddresses(List<Address> addresses, Config methodConfig);
+
+        /// <summary>
+        /// Retrieve a list of all carriers that have been added to this account
+        /// </summary>
+        /// <returns>A list of carriers</returns>
+        Task<ListCarriers.Result> ListCarriers();
+
+        /// <summary>
+        /// Retrieve a list of all carriers that have been added to this account
+        /// </summary>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call.</param>
+        /// <returns>A list of carriers</returns>
+        Task<ListCarriers.Result> ListCarriers(Config methodConfig);
+
+        /// <summary>
+        /// Create a manifest
+        /// </summary>
+        /// <param name="manifestParams">The details of the manifest you want to create.</param>
+        /// <returns></returns>
+        Task<Manifests.Result> CreateManifest(Manifests.Params manifestParams);
+
+        /// <summary>
+        /// Create a manifest
+        /// </summary>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call.</param>
+        /// <param name="manifestParams">The details of the manifest you want to create.</param>
+        /// <returns></returns>
+        Task<Manifests.Result> CreateManifest(Config methodConfig, Manifests.Params manifestParams);
+
+        /// <summary>
+        /// Void a label by ID to get a refund.
+        /// </summary>
+        /// <param name="labelId">The id of the label to void</param>
+        /// <returns>Result object indicating the success of the void label attempt</returns>
+        Task<VoidLabelWithLabelId.Result> VoidLabelWithLabelId(string labelId);
+
+        /// <summary>
+        /// Void a label by ID to get a refund.
+        /// </summary>
+        /// <param name="labelId">The id of the label to void</param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call</param>
+        /// <returns>Result object indicating the success of the void label attempt</returns>
+        Task<VoidLabelWithLabelId.Result> VoidLabelWithLabelId(string labelId, Config methodConfig);
+
+        /// <summary>
+        /// Track a shipment using the label id
+        /// </summary>
+        /// <param name="labelId">The label id associated with the shipment</param>
+        /// <returns>An object that contains the label id tracking information</returns>
+        Task<TrackUsingLabelId.Result> TrackUsingLabelId(string labelId);
+
+        /// <summary>
+        /// Track a shipment using the label id
+        /// </summary>
+        /// <param name="labelId">The label id associated with the shipment</param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call</param>
+        /// <returns>An object that contains the label id tracking information</returns>
+        Task<TrackUsingLabelId.Result> TrackUsingLabelId(string labelId, Config methodConfig);
+
+        /// <summary>
+        /// Tracks a package based on the trackingNumber and carrierCode.
+        /// </summary>
+        /// <param name="trackingNumber">The tracking number of the package you wish to track.</param>
+        /// <param name="carrierCode">The carrierCode for the trackingNumber you are using to track the package.</param>
+        /// <returns></returns>
+        Task<TrackUsingCarrierCodeAndTrackingNumber.Result> TrackUsingCarrierCodeAndTrackingNumber(string trackingNumber, string carrierCode);
+
+        /// <summary>
+        /// Tracks a package based on the trackingNumber and carrierCode.
+        /// </summary>
+        /// <param name="trackingNumber">The tracking number of the package you wish to track.</param>
+        /// <param name="carrierCode">The carrierCode for the trackingNumber you are using to track the package.</param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call</param>
+        /// <returns></returns>
+        Task<TrackUsingCarrierCodeAndTrackingNumber.Result> TrackUsingCarrierCodeAndTrackingNumber(string trackingNumber, string carrierCode, Config methodConfig);
+
+        /// <summary>
+        /// Create a label from shipment details
+        /// </summary>
+        /// <param name="labelParams">Details of the label that you want to create</param>
+        /// <returns>Object containing the created label information</returns>
+        Task<CreateLabelFromShipmentDetails.Result> CreateLabelFromShipmentDetails(CreateLabelFromShipmentDetails.Params labelParams);
+
+        /// <summary>
+        /// Create a label from shipment details
+        /// </summary>
+        /// <param name="labelParams">Details of the label that you want to create</param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call</param>
+        /// <returns>Object containing the created label information</returns>
+        Task<CreateLabelFromShipmentDetails.Result> CreateLabelFromShipmentDetails(CreateLabelFromShipmentDetails.Params labelParams, Config methodConfig);
+
+        /// <summary>
+        /// Create a label from a rate id
+        /// </summary>
+        /// <param name="createLabelFromRateParams">The details of the rate that you want to use to purchase a label</param>
+        /// <returns>Object containing the created label information</returns>
+        Task<CreateLabelFromRate.Result> CreateLabelFromRate(CreateLabelFromRate.Params createLabelFromRateParams);
+
+        /// <summary>
+        /// Create a label from a rate id
+        /// </summary>
+        /// <param name="createLabelFromRateParams">The details of the rate that you want to use to purchase a label</param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call</param>
+        /// <returns>Object containing the created label information</returns>
+        Task<CreateLabelFromRate.Result> CreateLabelFromRate(CreateLabelFromRate.Params createLabelFromRateParams, Config methodConfig);
+
+        /// <summary>
+        /// Retrieve rates for a package with the provided shipment details.
+        /// </summary>
+        /// <param name="rateParams"></param>
+        /// <returns>The rates result</returns>
+        Task<GetRatesWithShipmentDetails.Result> GetRatesWithShipmentDetails(GetRatesWithShipmentDetails.Params rateParams);
+
+        /// <summary>
+        /// Retrieve rates for a package with the provided shipment details.
+        /// </summary>
+        /// <param name="rateParams"></param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call</param>
+        /// <returns>The rates result</returns>
+        Task<GetRatesWithShipmentDetails.Result> GetRatesWithShipmentDetails(GetRatesWithShipmentDetails.Params rateParams, Config methodConfig);
+    }
+
+    /// <summary>
+    /// Mock implementation of IShipEngine
+    /// </summary>
+    public class ShipEngineMock : IShipEngine
+    {
+        /// <summary>
+        /// Validates an address in nearly any country in the world.
+        /// </summary>
+        /// <param name="addresses">The address to validate. This can even be an incomplete or improperly formatted address</param>
+        /// <returns>An address validation result object</returns>
+        public virtual Task<List<Result>> ValidateAddresses(List<Address> addresses)
+        {
+            return Task.FromResult(new List<Result>());
+        }
+
+        /// <summary>
+        /// Validates an address in nearly any country in the world.
+        /// </summary>
+        /// <param name="addresses">The address to validate. This can even be an incomplete or improperly formatted address</param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call.</param>
+        /// <returns>An address validation result object</returns>
+        public virtual Task<List<Result>> ValidateAddresses(List<Address> addresses, Config methodConfig)
+        {
+            return Task.FromResult(new List<Result>());
+        }
+
+        /// <summary>
+        /// Retrieve a list of all carriers that have been added to this account
+        /// </summary>
+        /// <returns>A list of carriers</returns>
+        public virtual Task<ListCarriers.Result> ListCarriers()
+        {
+            return Task.FromResult(new ListCarriers.Result());
+        }
+
+        /// <summary>
+        /// Retrieve a list of all carriers that have been added to this account
+        /// </summary>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call.</param>
+        /// <returns>A list of carriers</returns>
+        public virtual Task<ListCarriers.Result> ListCarriers(Config methodConfig)
+        {
+            return Task.FromResult(new ListCarriers.Result());
+        }
+
+        /// <summary>
+        /// Create a manifest
+        /// </summary>
+        /// <param name="manifestParams">The details of the manifest you want to create.</param>
+        /// <returns></returns>
+        public virtual Task<Manifests.Result> CreateManifest(Params manifestParams)
+        {
+            return Task.FromResult(new Manifests.Result());
+        }
+
+        /// <summary>
+        /// Create a manifest
+        /// </summary>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call.</param>
+        /// <param name="manifestParams">The details of the manifest you want to create.</param>
+        /// <returns></returns>
+        public virtual Task<Manifests.Result> CreateManifest(Config methodConfig, Params manifestParams)
+        {
+            return Task.FromResult(new Manifests.Result());
+        }
+
+        /// <summary>
+        /// Void a label by ID to get a refund.
+        /// </summary>
+        /// <param name="labelId">The id of the label to void</param>
+        /// <returns>Result object indicating the success of the void label attempt</returns>
+        public virtual Task<VoidLabelWithLabelId.Result> VoidLabelWithLabelId(string labelId)
+        {
+            return Task.FromResult(new VoidLabelWithLabelId.Result());
+        }
+
+        /// <summary>
+        /// Void a label by ID to get a refund.
+        /// </summary>
+        /// <param name="labelId">The id of the label to void</param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call</param>
+        /// <returns>Result object indicating the success of the void label attempt</returns>
+        public virtual Task<VoidLabelWithLabelId.Result> VoidLabelWithLabelId(string labelId, Config methodConfig)
+        {
+            return Task.FromResult(new VoidLabelWithLabelId.Result());
+        }
+
+        /// <summary>
+        /// Track a shipment using the label id
+        /// </summary>
+        /// <param name="labelId">The label id associated with the shipment</param>
+        /// <returns>An object that contains the label id tracking information</returns>
+        public virtual Task<TrackUsingLabelId.Result> TrackUsingLabelId(string labelId)
+        {
+            return Task.FromResult(new TrackUsingLabelId.Result());
+        }
+
+        /// <summary>
+        /// Track a shipment using the label id
+        /// </summary>
+        /// <param name="labelId">The label id associated with the shipment</param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call</param>
+        /// <returns>An object that contains the label id tracking information</returns>
+        public virtual Task<TrackUsingLabelId.Result> TrackUsingLabelId(string labelId, Config methodConfig)
+        {
+            return Task.FromResult(new TrackUsingLabelId.Result());
+        }
+
+        /// <summary>
+        /// Tracks a package based on the trackingNumber and carrierCode.
+        /// </summary>
+        /// <param name="trackingNumber">The tracking number of the package you wish to track.</param>
+        /// <param name="carrierCode">The carrierCode for the trackingNumber you are using to track the package.</param>
+        /// <returns></returns>
+        public virtual Task<TrackUsingCarrierCodeAndTrackingNumber.Result> TrackUsingCarrierCodeAndTrackingNumber(string trackingNumber, string carrierCode)
+        {
+            return Task.FromResult(new TrackUsingCarrierCodeAndTrackingNumber.Result());
+        }
+
+        /// <summary>
+        /// Tracks a package based on the trackingNumber and carrierCode.
+        /// </summary>
+        /// <param name="trackingNumber">The tracking number of the package you wish to track.</param>
+        /// <param name="carrierCode">The carrierCode for the trackingNumber you are using to track the package.</param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call</param>
+        /// <returns></returns>
+        public virtual Task<TrackUsingCarrierCodeAndTrackingNumber.Result> TrackUsingCarrierCodeAndTrackingNumber(string trackingNumber, string carrierCode, Config methodConfig)
+        {
+            return Task.FromResult(new TrackUsingCarrierCodeAndTrackingNumber.Result());
+        }
+
+        /// <summary>
+        /// Create a label from shipment details
+        /// </summary>
+        /// <param name="labelParams">Details of the label that you want to create</param>
+        /// <returns>Object containing the created label information</returns>
+        public virtual Task<CreateLabelFromShipmentDetails.Result> CreateLabelFromShipmentDetails(CreateLabelFromShipmentDetails.Params labelParams)
+        {
+            return Task.FromResult(new CreateLabelFromShipmentDetails.Result());
+        }
+
+        /// <summary>
+        /// Create a label from shipment details
+        /// </summary>
+        /// <param name="labelParams">Details of the label that you want to create</param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call</param>
+        /// <returns>Object containing the created label information</returns>
+        public virtual Task<CreateLabelFromShipmentDetails.Result> CreateLabelFromShipmentDetails(CreateLabelFromShipmentDetails.Params labelParams, Config methodConfig)
+        {
+            return Task.FromResult(new CreateLabelFromShipmentDetails.Result());
+        }
+
+        /// <summary>
+        /// Create a label from a rate id
+        /// </summary>
+        /// <param name="createLabelFromRateParams">The details of the rate that you want to use to purchase a label</param>
+        /// <returns>Object containing the created label information</returns>
+        public virtual Task<CreateLabelFromRate.Result> CreateLabelFromRate(CreateLabelFromRate.Params createLabelFromRateParams)
+        {
+            return Task.FromResult(new CreateLabelFromRate.Result());
+        }
+
+        /// <summary>
+        /// Create a label from a rate id
+        /// </summary>
+        /// <param name="createLabelFromRateParams">The details of the rate that you want to use to purchase a label</param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call</param>
+        /// <returns>Object containing the created label information</returns>
+        public virtual Task<CreateLabelFromRate.Result> CreateLabelFromRate(CreateLabelFromRate.Params createLabelFromRateParams, Config methodConfig)
+        {
+            return Task.FromResult(new CreateLabelFromRate.Result());
+        }
+
+        /// <summary>
+        /// Retrieve rates for a package with the provided shipment details.
+        /// </summary>
+        /// <param name="rateParams"></param>
+        /// <returns>The rates result</returns>
+        public virtual Task<GetRatesWithShipmentDetails.Result> GetRatesWithShipmentDetails(GetRatesWithShipmentDetails.Params rateParams)
+        {
+            return Task.FromResult(new GetRatesWithShipmentDetails.Result());
+        }
+
+        /// <summary>
+        /// Retrieve rates for a package with the provided shipment details.
+        /// </summary>
+        /// <param name="rateParams"></param>
+        /// <param name="methodConfig">Configuration object that overrides the global config for this method call</param>
+        /// <returns>The rates result</returns>
+        public virtual Task<GetRatesWithShipmentDetails.Result> GetRatesWithShipmentDetails(GetRatesWithShipmentDetails.Params rateParams, Config methodConfig)
+        {
+            return Task.FromResult(new GetRatesWithShipmentDetails.Result());
+        }
+    }
+
     /// <summary>
     /// Extension method to allow customized client configuration
     /// </summary>
@@ -38,7 +376,7 @@ namespace ShipEngineSDK
     /// <summary>
     /// Contains methods for interacting with the ShipEngine API.
     /// </summary>
-    public class ShipEngine : ShipEngineClient, IDisposable
+    public class ShipEngine : ShipEngineClient, IDisposable, IShipEngine
     {
         /// <summary>
         /// Global HttpClient for ShipEngine instance.

--- a/ShipEngine/ShipEngine.csproj
+++ b/ShipEngine/ShipEngine.csproj
@@ -28,9 +28,12 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="System.Text.Json" Version="8.0.3" />
-		<None Include="..\README.md" Pack="true" PackagePath="\"/>
+		<None Include="..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ShipEngine/ShipEngine.csproj
+++ b/ShipEngine/ShipEngine.csproj
@@ -4,7 +4,7 @@
 		<PackageId>ShipEngine</PackageId>
 		<PackageTags>sdk;rest;api;shipping;rates;label;tracking;cost;address;validation;normalization;fedex;ups;usps;</PackageTags>
 
-		<Version>2.0.1</Version>
+		<Version>2.0.2</Version>
 		<Authors>ShipEngine</Authors>
 		<Company>ShipEngine</Company>
 		<Summary>The official ShipEngine C# SDK for .NET</Summary>

--- a/ShipEngine/ShipEngineClient.cs
+++ b/ShipEngine/ShipEngineClient.cs
@@ -127,7 +127,7 @@ namespace ShipEngineSDK
         {
             int retry = 0;
 
-            HttpResponseMessage response = null;
+            HttpResponseMessage? response = null;
             ShipEngineException requestException;
             while (true)
             {
@@ -176,7 +176,7 @@ namespace ShipEngineSDK
             }
         }
 
-        private async Task WaitAndRetry(HttpResponseMessage response, Config config, ShipEngineException ex)
+        private async Task WaitAndRetry(HttpResponseMessage? response, Config config, ShipEngineException ex)
         {
             int? retryAfter;
 

--- a/ShipEngine/ShipEngineClient.cs
+++ b/ShipEngine/ShipEngineClient.cs
@@ -95,6 +95,7 @@ namespace ShipEngineSDK
                         error.ErrorSource,
                         error.ErrorType,
                         error.ErrorCode,
+                        response,
                         deserializedError.RequestId
                     );
                 }
@@ -196,6 +197,7 @@ namespace ShipEngineSDK
                     ErrorSource.Shipengine,
                     ErrorType.System,
                     ErrorCode.Timeout,
+                    ex.ResponseMessage,
                     ex.RequestId
                 );
             }


### PR DESCRIPTION
- Adds the ability to initialize SDK with an HttpClient, and to make modifications to subsequent requests
- Adds cancellation token to client
- Adds HttpResponseMessage to ShipEngineException
- Adds missing markdown
- Redefines several properties as nullable reference types
- Adds and implements IShipEngine interface with virtual mockable ShipEngine