### PR TITLE
Handle unexpected HTTP responses

### DIFF
--- a/ShipEngine.Tests/Helpers/MockShipEngineFixture.cs
+++ b/ShipEngine.Tests/Helpers/MockShipEngineFixture.cs
@@ -3,6 +3,7 @@ namespace ShipEngineTest
     using Moq;
     using Moq.Protected;
     using ShipEngineSDK;
+    using System;
     using System.Net;
     using System.Net.Http;
     using System.Text.Json;
@@ -74,10 +75,13 @@ namespace ShipEngineTest
         /// <param name="path">The HTTP path.</param>
         /// <param name="status">The status code to return.</param>
         /// <param name="response">The response body to return.</param>
-        public void StubRequest(HttpMethod method, string path, HttpStatusCode status, string response)
+        public string StubRequest(HttpMethod method, string path, HttpStatusCode status, string response)
         {
+            var requestId = Guid.NewGuid().ToString();
             var responseMessage = new HttpResponseMessage(status);
             responseMessage.Content = new StringContent(response);
+            responseMessage.Headers.Add("x-shipengine-requestid", requestId);
+            responseMessage.Headers.Add("request-id", requestId);
 
             MockHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>(
@@ -87,6 +91,7 @@ namespace ShipEngineTest
                         m.RequestUri.AbsolutePath == path),
                     ItExpr.IsAny<CancellationToken>())
                 .Returns(Task.FromResult(responseMessage));
+            return requestId;
         }
     }
 }

--- a/ShipEngine.Tests/ShipEngineClientTests.cs
+++ b/ShipEngine.Tests/ShipEngineClientTests.cs
@@ -1,0 +1,115 @@
+namespace ShipEngineTest
+{
+    using ShipEngineSDK;
+    using ShipEngineSDK.VoidLabelWithLabelId;
+    using System;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class ShipEngineClientTests
+    {
+        [Fact]
+        public async Task FailureWithShipengineResponseThrowsPopulatedShipEngineException()
+        {
+            var config = new Config(apiKey: "test", timeout: TimeSpan.FromSeconds(0.5));
+            var mockShipEngineFixture = new MockShipEngineFixture(config);
+            var shipengine = mockShipEngineFixture.ShipEngine;
+
+
+            string requestId = "12345";
+            string message = "Request body cannot be empty.";
+            var responseBody = string.Format(
+                @"
+                  {{
+                      ""request_id"": ""{0}"",
+                      ""errors"": [
+                        {{
+                          ""error_source"": ""shipengine"",
+                          ""error_type"": ""validation"",
+                          ""error_code"": ""request_body_required"",
+                          ""message"": ""{1}""
+                        }}
+                      ]
+                  }}", requestId, message);
+
+
+            mockShipEngineFixture.StubRequest(HttpMethod.Post, "/v1/something", System.Net.HttpStatusCode.BadRequest,
+                responseBody);
+            var ex = await Assert.ThrowsAsync<ShipEngineException>(
+                async () => await shipengine.SendHttpRequestAsync<Result>(HttpMethod.Post, "/v1/something", "",
+                    mockShipEngineFixture.HttpClient, config)
+            );
+
+            Assert.Equal(requestId, ex.RequestId);
+            Assert.Equal(message, ex.Message);
+            Assert.Equal(ErrorSource.Shipengine, ex.ErrorSource);
+            Assert.Equal(ErrorType.Validation, ex.ErrorType);
+            Assert.Equal(ErrorCode.RequestBodyRequired, ex.ErrorCode);
+            Assert.NotNull(ex.ResponseMessage);
+            Assert.Equal(400, (int)ex.ResponseMessage.StatusCode);
+        }
+
+        [Fact]
+        public async Task FailureWithoutShipengineResponseThrowsHttpException()
+        {
+            var config = new Config(apiKey: "test", timeout: TimeSpan.FromSeconds(0.5));
+            var mockShipEngineFixture = new MockShipEngineFixture(config);
+            var shipengine = mockShipEngineFixture.ShipEngine;
+
+            var responseBody = @"<h1>Bad Gateway</h1>";
+            mockShipEngineFixture.StubRequest(HttpMethod.Post, "/v1/something", System.Net.HttpStatusCode.BadGateway,
+                responseBody);
+            var ex = await Assert.ThrowsAsync<HttpRequestException>(
+                async () => await shipengine.SendHttpRequestAsync<Result>(HttpMethod.Post, "/v1/something", "",
+                    mockShipEngineFixture.HttpClient, config)
+            );
+
+            Assert.Contains("502", ex.Message);
+        }
+
+        [Fact]
+        public async Task FailureToParseSuccessResponseThrowsExceptionWithUnparsedResponse()
+        {
+            var config = new Config(apiKey: "test", timeout: TimeSpan.FromSeconds(0.5));
+            var mockShipEngineFixture = new MockShipEngineFixture(config);
+            var shipengine = mockShipEngineFixture.ShipEngine;
+
+            var responseBody = @"Unexpected response - not JSON";
+            mockShipEngineFixture.StubRequest(HttpMethod.Post, "/v1/something", System.Net.HttpStatusCode.OK,
+                responseBody);
+            var ex = await Assert.ThrowsAsync<ShipEngineException>(
+                async () => await shipengine.SendHttpRequestAsync<Result>(HttpMethod.Post, "/v1/something", "",
+                    mockShipEngineFixture.HttpClient, config)
+            );
+            mockShipEngineFixture.AssertRequest(HttpMethod.Post, "/v1/something");
+
+            Assert.NotNull(ex.ResponseMessage);
+            Assert.Equal(200, (int)ex.ResponseMessage.StatusCode);
+            Assert.Equal(responseBody, await ex.ResponseMessage.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task NullStringResponseThrowsExceptionWithUnparsedResponse()
+        {
+            var config = new Config(apiKey: "test", timeout: TimeSpan.FromSeconds(0.5));
+            var mockShipEngineFixture = new MockShipEngineFixture(config);
+            var shipengine = mockShipEngineFixture.ShipEngine;
+
+            // this scenario is similar to unparseable JSON - except that it is valid JSON
+            var responseBody = @"null";
+            mockShipEngineFixture.StubRequest(HttpMethod.Post, "/v1/something", System.Net.HttpStatusCode.OK,
+                responseBody);
+            var ex = await Assert.ThrowsAsync<ShipEngineException>(
+                async () => await shipengine.SendHttpRequestAsync<Result>(HttpMethod.Post, "/v1/something", "",
+                    mockShipEngineFixture.HttpClient, config)
+            );
+            mockShipEngineFixture.AssertRequest(HttpMethod.Post, "/v1/something");
+
+            Assert.NotNull(ex.ResponseMessage);
+            Assert.Equal("Unexpected null response", ex.Message);
+            Assert.Equal(200, (int)ex.ResponseMessage.StatusCode);
+            Assert.Equal(responseBody, await ex.ResponseMessage.Content.ReadAsStringAsync());
+        }
+    }
+}

--- a/ShipEngine.Tests/ShipEngineClientTests.cs
+++ b/ShipEngine.Tests/ShipEngineClientTests.cs
@@ -58,7 +58,7 @@ namespace ShipEngineTest
             var shipengine = mockShipEngineFixture.ShipEngine;
 
             var responseBody = @"{""description"": ""valid JSON, but not what you expect""}";
-            mockShipEngineFixture.StubRequest(HttpMethod.Get, "/v1/something", System.Net.HttpStatusCode.NotFound,
+            var requestId = mockShipEngineFixture.StubRequest(HttpMethod.Get, "/v1/something", System.Net.HttpStatusCode.NotFound,
                 responseBody);
             var ex = await Assert.ThrowsAsync<ShipEngineException>(
                 async () => await shipengine.SendHttpRequestAsync<Result>(HttpMethod.Get, "/v1/something", null,
@@ -67,6 +67,7 @@ namespace ShipEngineTest
 
             Assert.NotNull(ex.ResponseMessage);
             Assert.Equal(404, (int) ex.ResponseMessage.StatusCode);
+            Assert.Equal(requestId, ex.RequestId);
         }
 
         [Fact]
@@ -77,7 +78,7 @@ namespace ShipEngineTest
             var shipengine = mockShipEngineFixture.ShipEngine;
 
             var responseBody = @"<h1>Bad Gateway</h1>";
-            mockShipEngineFixture.StubRequest(HttpMethod.Post, "/v1/something", System.Net.HttpStatusCode.BadGateway,
+            var requestId = mockShipEngineFixture.StubRequest(HttpMethod.Post, "/v1/something", System.Net.HttpStatusCode.BadGateway,
                 responseBody);
             var ex = await Assert.ThrowsAsync<ShipEngineException>(
                 async () => await shipengine.SendHttpRequestAsync<Result>(HttpMethod.Post, "/v1/something", "",
@@ -86,6 +87,7 @@ namespace ShipEngineTest
 
             Assert.NotNull(ex.ResponseMessage);
             Assert.Equal(502, (int) ex.ResponseMessage.StatusCode);
+            Assert.Equal(requestId, ex.RequestId);
         }
 
         [Fact]
@@ -96,7 +98,7 @@ namespace ShipEngineTest
             var shipengine = mockShipEngineFixture.ShipEngine;
 
             var responseBody = @"Unexpected response - not JSON";
-            mockShipEngineFixture.StubRequest(HttpMethod.Post, "/v1/something", System.Net.HttpStatusCode.OK,
+            var requestId = mockShipEngineFixture.StubRequest(HttpMethod.Post, "/v1/something", System.Net.HttpStatusCode.OK,
                 responseBody);
             var ex = await Assert.ThrowsAsync<ShipEngineException>(
                 async () => await shipengine.SendHttpRequestAsync<Result>(HttpMethod.Post, "/v1/something", "",
@@ -107,6 +109,7 @@ namespace ShipEngineTest
             Assert.NotNull(ex.ResponseMessage);
             Assert.Equal(200, (int)ex.ResponseMessage.StatusCode);
             Assert.Equal(responseBody, await ex.ResponseMessage.Content.ReadAsStringAsync());
+            Assert.Equal(requestId, ex.RequestId);
         }
 
         [Fact]
@@ -118,7 +121,7 @@ namespace ShipEngineTest
 
             // this scenario is similar to unparseable JSON - except that it is valid JSON
             var responseBody = @"null";
-            mockShipEngineFixture.StubRequest(HttpMethod.Post, "/v1/something", System.Net.HttpStatusCode.OK,
+            var requestId = mockShipEngineFixture.StubRequest(HttpMethod.Post, "/v1/something", System.Net.HttpStatusCode.OK,
                 responseBody);
             var ex = await Assert.ThrowsAsync<ShipEngineException>(
                 async () => await shipengine.SendHttpRequestAsync<Result>(HttpMethod.Post, "/v1/something", "",
@@ -130,6 +133,7 @@ namespace ShipEngineTest
             Assert.Equal("Unexpected null response", ex.Message);
             Assert.Equal(200, (int)ex.ResponseMessage.StatusCode);
             Assert.Equal(responseBody, await ex.ResponseMessage.Content.ReadAsStringAsync());
+            Assert.Equal(requestId, ex.RequestId);
         }
     }
 }


### PR DESCRIPTION
This will better handle the situation where the HTTP response body cannot be parsed as JSON.
Instead of throwing a `JsonException`, we will throw a `ShipEngineException` containing the `HttpResponseMessage`. This will give the caller a chance to handle the response in their own way.

We will also try to include a request ID on all `ShipeEngineException` now - by pulling from the response header in cases where we don't get a ShipEngine Error JSON response.