### PR TITLE
Allow setting alternate base address on HTTP Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,3 +132,10 @@ Updated references to use proper converter to resolve enum string values
 ### Changed
 
 Impoved handling of unexpected HTTP responses
+
+## 2.0.4
+
+### Changed
+
+- Allow setting alternate base address on HTTP Client
+- Moved the SDK version to static fields so they are only determined once at startup.

--- a/ShipEngine.Tests/ShipEngineClientTests.cs
+++ b/ShipEngine.Tests/ShipEngineClientTests.cs
@@ -3,12 +3,66 @@ namespace ShipEngineTest
     using ShipEngineSDK;
     using ShipEngineSDK.VoidLabelWithLabelId;
     using System;
+    using System.Linq;
     using System.Net.Http;
     using System.Threading.Tasks;
     using Xunit;
 
     public class ShipEngineClientTests
     {
+        [Fact]
+        public void ConfigureSetsDefaultBaseAddressOnHttpClient()
+        {
+            var httpClient = new HttpClient();
+            var returnedClient = ShipEngineClient.ConfigureHttpClient(httpClient, "my-api-key", null);
+
+            Assert.Same(httpClient, returnedClient);
+            Assert.Equal("https://api.shipengine.com/", httpClient.BaseAddress.ToString());
+        }
+
+        [Fact]
+        public void ConfigureAllowsSettingBaseAddressOnHttpClient()
+        {
+            var httpClient = new HttpClient();
+            var returnedClient = ShipEngineClient.ConfigureHttpClient(httpClient, "my-api-key", new Uri("http://localhost:5454/"));
+
+            Assert.Same(httpClient, returnedClient);
+            Assert.Equal("http://localhost:5454/", httpClient.BaseAddress.ToString());
+        }
+
+        [Fact]
+        public void ConfigureAllowsSettingTimeoutOnHttpClient()
+        {
+            var httpClient = new HttpClient();
+            var returnedClient = ShipEngineClient.ConfigureHttpClient(httpClient, "my-api-key", null, TimeSpan.FromMinutes(7));
+
+            Assert.Same(httpClient, returnedClient);
+            Assert.Equal(7, httpClient.Timeout.TotalMinutes);
+        }
+
+        [Fact]
+        public void ConfigureSetsTheApiKeyHeader()
+        {
+            var httpClient = new HttpClient();
+            var returnedClient = ShipEngineClient.ConfigureHttpClient(httpClient, "my-api-key", null);
+
+            Assert.Same(httpClient, returnedClient);
+            Assert.Equal("my-api-key", httpClient.DefaultRequestHeaders.FirstOrDefault(x => x.Key == "Api-Key").Value.SingleOrDefault());
+        }
+
+        [Fact]
+        public void ConfigureSetsTheSdkUserAgentHeader()
+        {
+            var httpClient = new HttpClient();
+            var returnedClient = ShipEngineClient.ConfigureHttpClient(httpClient, "my-api-key", null);
+
+            Assert.Same(httpClient, returnedClient);
+            var userAgents = httpClient.DefaultRequestHeaders.FirstOrDefault(x => x.Key == "User-Agent").Value;
+            Assert.NotNull(userAgents);
+            var sdkHeader = userAgents.FirstOrDefault(x => x.StartsWith("shipengine-dotnet/"));
+            Assert.NotNull(sdkHeader);
+        }
+
         [Fact]
         public async Task FailureStatusWithShipengineContentThrowsPopulatedShipEngineException()
         {

--- a/ShipEngine/ShipEngine.csproj
+++ b/ShipEngine/ShipEngine.csproj
@@ -4,7 +4,7 @@
 		<PackageId>ShipEngine</PackageId>
 		<PackageTags>sdk;rest;api;shipping;rates;label;tracking;cost;address;validation;normalization;fedex;ups;usps;</PackageTags>
 
-		<Version>2.0.3</Version>
+		<Version>2.0.4</Version>
 		<Authors>ShipEngine</Authors>
 		<Company>ShipEngine</Company>
 		<Summary>The official ShipEngine C# SDK for .NET</Summary>

--- a/ShipEngine/ShipEngineClient.cs
+++ b/ShipEngine/ShipEngineClient.cs
@@ -31,6 +31,12 @@ namespace ShipEngineSDK
             Converters = { new JsonStringEnumMemberConverter() }
         };
 
+        private static readonly string? OsPlatform = Environment.OSVersion.Platform.ToString();
+        private static readonly string? OsVersion = Environment.OSVersion.Version.ToString();
+        private static readonly string? ClrVersion = Environment.Version.ToString();
+        private static readonly Version? SdkVersionObject = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
+        private static readonly string SdkVersion = $"{SdkVersionObject.Major}.{SdkVersionObject.Minor}.{SdkVersionObject.Build}";
+
         private const string JsonMediaType = "application/json";
 
         /// <summary>
@@ -49,20 +55,16 @@ namespace ShipEngineSDK
         {
             client.DefaultRequestHeaders.Accept.Clear();
 
-            var osPlatform = Environment.OSVersion.Platform.ToString();
-            var osVersion = Environment.OSVersion.Version.ToString();
-            var clrVersion = Environment.Version.ToString();
-
-            var sdkVersionObject = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
-            var sdkVersion = $"{sdkVersionObject.Major}.{sdkVersionObject.Minor}.{sdkVersionObject.Build}";
-
-            var userAgentString = $"shipengine-dotnet/{sdkVersion} {osPlatform}/{osVersion} clr/{clrVersion}";
+            var userAgentString = $"shipengine-dotnet/{SdkVersion} {OsPlatform}/{OsVersion} clr/{ClrVersion}";
 
             client.DefaultRequestHeaders.Add("User-Agent", userAgentString);
             client.DefaultRequestHeaders.Add("Api-Key", config.ApiKey);
             client.DefaultRequestHeaders.Add("Accept", JsonMediaType);
 
-            client.BaseAddress = new Uri("https://api.shipengine.com");
+            if (client.BaseAddress == null)
+            {
+                client.BaseAddress = new Uri("https://api.shipengine.com");
+            }
 
             client.Timeout = config.Timeout;
 


### PR DESCRIPTION
The `ConfigureHttpClient` method accepted a Uri to set as the BaseAddress on the HttpClient, but it overwrote it with the default address.

Also moved the SDK version to static fields so they are only determined once at startup.