### PR TITLE
Fix an error when publishing to Nuget

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: publish on version change
         id: publish_nuget
-        uses: brandedoutcast/publish-nuget@v2.5.5
+        uses: alirezanet/publish-nuget@v3.1.0
 
         with:
           # Filepath of the project to be packaged, relative to root of repository


### PR DESCRIPTION
When publishing to Nuget, the Github Action fails with an error "Error: 😭 error: File does not exist (1).".  This seems to be a [known issue](https://github.com/brandedoutcast/publish-nuget/issues/76) and the suggestions seem to be either write your own script (which probably isn't a bad idea) or use a more up-to-date [fork](https://github.com/alirezanet/publish-nuget) of the action.  I elected to try the latter.