### PR TITLE
Added error codes for funding sources errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-
 ## 1.0.0
 
 ### Features
@@ -16,15 +15,13 @@ Implement the following SDK methods.
 - `CreateLabelFromRate`
 - `GetRatesWithShipmentDetails`
 
-
 ## 1.0.7
 
 ### Features
 
 Implement the following SDK methods.
+
 - `CreateImplicitManifest`
-
-
 
 ## 1.1.0
 
@@ -41,7 +38,6 @@ Rename LabelDownload method to the more generic Download
 
 Some documentation linking errors and minor typos
 
-
 ## 1.1.1
 
 ### Added
@@ -51,7 +47,6 @@ Some documentation linking errors and minor typos
 ### Fixed
 
 The Customs Item Quantity type has been changed to integer type for CreateLabelFromShipmentDetails model.
-
 
 ## 1.1.2
 
@@ -150,7 +145,7 @@ Updated nuget package dependencies
 
 ### Added
 
-- Created new SDK methods for the entire API that sit next to the pre-existing methods.  The pre-existing methods will be deprecated eventually.
+- Created new SDK methods for the entire API that sit next to the pre-existing methods. The pre-existing methods will be deprecated eventually.
 
 ## 2.2.0
 
@@ -175,7 +170,7 @@ Fixed handling of No Content responses
 
 - Added ability to scope request modifiers by using the `.WithRequestModifier()` method instead of the `.ModifyRequest` property.
   This will allow consumers to modify a single request without affecting any other consumers of the client. It also allows for
-  multiple modifiers to be added.  For example, a modifier could be added at the global level that applies to all requests and then
+  multiple modifiers to be added. For example, a modifier could be added at the global level that applies to all requests and then
   another modifier can be added for a single request.
 
 ## 2.3.1
@@ -201,3 +196,10 @@ Fixed handling of No Content responses
 ### Added
 
 - Added error code MultipackageNotSupported
+
+## 2.3.5
+
+### Added
+
+- Added error code FundingSourceMissingConfiguration
+- Added error code FundingSourceError

--- a/ShipEngineSDK/Enums/ErrorCode.cs
+++ b/ShipEngineSDK/Enums/ErrorCode.cs
@@ -261,5 +261,17 @@ namespace ShipEngineSDK
         /// </summary>
         [EnumMember(Value = "webhook_event_type_conflict")]
         WebhookEventTypeConflict,
+
+        /// <summary>
+        /// Funding source isnt properly configured and can't be used.
+        /// </summary>
+        [EnumMember(Value = "funding_source_missing_configuration")]
+        FundingSourceMissingConfiguration,
+
+        /// <summary>
+        /// There was an unexpected problem with a funding source.
+        /// </summary>
+        [EnumMember(Value = "funding_source_error")]
+        FundingSourceError,
     }
 }

--- a/ShipEngineSDK/Enums/ErrorType.cs
+++ b/ShipEngineSDK/Enums/ErrorType.cs
@@ -41,6 +41,18 @@ namespace ShipEngineSDK
         /// An unknown or unexpected error occurred in our system. Or an error occurred that has not yet been assigned a specific error_type. If you receive persistent system errors, then please contact our support or check our API status page to see if there's a known issue.
         /// </summary>/
         [EnumMember(Value = "system")]
-        System
+        System,
+
+        /// <summary>
+        /// General wallet error type.
+        /// </summary>/
+        [EnumMember(Value = "wallet")]
+        Wallet,
+
+        /// <summary>
+        /// General funding sources error type.
+        /// </summary>/
+        [EnumMember(Value = "funding_sources")]
+        FundingSources
     }
 }

--- a/ShipEngineSDK/PublicAPI.Shipped.txt
+++ b/ShipEngineSDK/PublicAPI.Shipped.txt
@@ -872,6 +872,8 @@ ShipEngineSDK.ErrorCode.Unspecified = 35 -> ShipEngineSDK.ErrorCode
 ShipEngineSDK.ErrorCode.VerificationFailure = 36 -> ShipEngineSDK.ErrorCode
 ShipEngineSDK.ErrorCode.WarehouseConflict = 37 -> ShipEngineSDK.ErrorCode
 ShipEngineSDK.ErrorCode.WebhookEventTypeConflict = 38 -> ShipEngineSDK.ErrorCode
+ShipEngineSDK.ErrorCode.FundingSourceMissingConfiguration = 39 -> ShipEngineSDK.ErrorCode
+ShipEngineSDK.ErrorCode.FundingSourceError = 40 -> ShipEngineSDK.ErrorCode
 ShipEngineSDK.ErrorSource
 ShipEngineSDK.ErrorSource.Carrier = 1 -> ShipEngineSDK.ErrorSource
 ShipEngineSDK.ErrorSource.OrderSource = 2 -> ShipEngineSDK.ErrorSource

--- a/ShipEngineSDK/PublicAPI.Unshipped.txt
+++ b/ShipEngineSDK/PublicAPI.Unshipped.txt
@@ -433,6 +433,8 @@ ShipEngineSDK.Enums.ErrorCode.Unspecified = 35 -> ShipEngineSDK.Enums.ErrorCode
 ShipEngineSDK.Enums.ErrorCode.VerificationFailure = 36 -> ShipEngineSDK.Enums.ErrorCode
 ShipEngineSDK.Enums.ErrorCode.WarehouseConflict = 37 -> ShipEngineSDK.Enums.ErrorCode
 ShipEngineSDK.Enums.ErrorCode.WebhookEventTypeConflict = 38 -> ShipEngineSDK.Enums.ErrorCode
+ShipEngineSDK.Enums.ErrorCode.FundingSourceMissingConfiguration = 39 -> ShipEngineSDK.Enums.ErrorCode
+ShipEngineSDK.Enums.ErrorCode.FundingSourceError = 40 -> ShipEngineSDK.Enums.ErrorCode
 ShipEngineSDK.Enums.ErrorSource
 ShipEngineSDK.Enums.ErrorSource.Carrier = 1 -> ShipEngineSDK.Enums.ErrorSource
 ShipEngineSDK.Enums.ErrorSource.OrderSource = 2 -> ShipEngineSDK.Enums.ErrorSource
@@ -5718,6 +5720,8 @@ static ShipEngineSDK.Model.ErrorCode.Unspecified.get -> ShipEngineSDK.Model.Erro
 static ShipEngineSDK.Model.ErrorCode.VerificationFailure.get -> ShipEngineSDK.Model.ErrorCode!
 static ShipEngineSDK.Model.ErrorCode.WarehouseConflict.get -> ShipEngineSDK.Model.ErrorCode!
 static ShipEngineSDK.Model.ErrorCode.WebhookEventTypeConflict.get -> ShipEngineSDK.Model.ErrorCode!
+static ShipEngineSDK.Model.ErrorCode.FundingSourceMissingConfiguration.get -> ShipEngineSDK.Model.ErrorCode!
+static ShipEngineSDK.Model.ErrorCode.FundingSourceError.get -> ShipEngineSDK.Model.ErrorCode!
 static ShipEngineSDK.Model.ErrorSource.Carrier.get -> ShipEngineSDK.Model.ErrorSource!
 static ShipEngineSDK.Model.ErrorSource.OrderSource.get -> ShipEngineSDK.Model.ErrorSource!
 static ShipEngineSDK.Model.ErrorSource.Shipengine.get -> ShipEngineSDK.Model.ErrorSource!

--- a/ShipEngineSDK/ShipEngineSDK.csproj
+++ b/ShipEngineSDK/ShipEngineSDK.csproj
@@ -4,7 +4,7 @@
 		<PackageId>ShipEngine</PackageId>
 		<PackageTags>sdk;rest;api;shipping;rates;label;tracking;cost;address;validation;normalization;fedex;ups;usps;</PackageTags>
 
-		<Version>2.3.4</Version>
+		<Version>2.3.5</Version>
 		<Authors>ShipEngine</Authors>
 		<Company>ShipEngine</Company>
 		<Summary>The official ShipEngine C# SDK for .NET</Summary>

--- a/generation/swagger.json
+++ b/generation/swagger.json
@@ -5691,7 +5691,9 @@
           "incompatible_paired_labels",
           "invalid_charge_event",
           "invalid_object",
-          "no_rates_returned"
+          "no_rates_returned",
+          "funding_source_missing_configuration",
+          "funding_source_error"
         ],
         "description": "The error code specified for the failed API Call"
       },

--- a/generation/swagger.json
+++ b/generation/swagger.json
@@ -5641,7 +5641,9 @@
           "validation",
           "security",
           "system",
-          "integrations"
+          "integrations",
+          "wallet",
+          "funding_sources"
         ],
         "description": "The type of error\n"
       },

--- a/openapitools.json
+++ b/openapitools.json
@@ -13,7 +13,7 @@
         "packageName": "ShipEngineSDK",
         "ignoreFileOverride": "./.openapi-generator-ignore",
         "additionalProperties": {
-          "packageVersion": "2.3.4",
+          "packageVersion": "2.3.5",
           "targetFramework": "netstandard2.0",
           "validatable": false,
           "sourceFolder": "",


### PR DESCRIPTION
There are some common errors while interacting with funding sources that are not handled correctly. Two of them are that when we throw a PreSetupWalletException or a WalletException we return a "An unexpected error occurred" instead of a more understandable error.
JIRA: https://auctane.atlassian.net/browse/ENGINE-7190
ShipEngine: https://github.com/shipstation/shipstation/pull/20482
SE Documentation: https://github.com/ShipEngine/shipengine-api-definition/pull/114