### PR TITLE
Return the HTTP response status and headers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,25 @@
     "omnisharp.useEditorFormattingSettings": false,
     "[csharp]": {
         "editor.defaultFormatter": "ms-dotnettools.csharp"
-    }
+    },
+    "workbench.colorCustomizations": {
+      "activityBar.activeBackground": "#26b7e8",
+      "activityBar.background": "#26b7e8",
+      "activityBar.foreground": "#15202b",
+      "activityBar.inactiveForeground": "#15202b99",
+      "activityBarBadge.background": "#ca159c",
+      "activityBarBadge.foreground": "#e7e7e7",
+      "commandCenter.border": "#e7e7e799",
+      "sash.hoverBorder": "#26b7e8",
+      "statusBar.background": "#1599c6",
+      "statusBar.foreground": "#e7e7e7",
+      "statusBarItem.hoverBackground": "#26b7e8",
+      "statusBarItem.remoteBackground": "#1599c6",
+      "statusBarItem.remoteForeground": "#e7e7e7",
+      "titleBar.activeBackground": "#1599c6",
+      "titleBar.activeForeground": "#e7e7e7",
+      "titleBar.inactiveBackground": "#1599c699",
+      "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.color": "#1599c6"
 }

--- a/ShipEngineSDK/Api/AccountApi.cs
+++ b/ShipEngineSDK/Api/AccountApi.cs
@@ -192,10 +192,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AccountApi.CreateAccountImage";
 
-        var (data, response) = await GetHttpResponse<GetAccountSettingsImagesResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetAccountSettingsImagesResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetAccountSettingsImagesResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -235,10 +232,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AccountApi.DeleteAccountImageById";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -278,10 +272,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AccountApi.GetAccountSettingsImagesById";
 
-        var (data, response) = await GetHttpResponse<GetAccountSettingsImagesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetAccountSettingsImagesResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetAccountSettingsImagesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -312,10 +303,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AccountApi.ListAccountImages";
 
-        var (data, response) = await GetHttpResponse<ListAccountSettingsImagesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ListAccountSettingsImagesResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ListAccountSettingsImagesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -346,10 +334,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AccountApi.ListAccountSettings";
 
-        var (data, response) = await GetHttpResponse<GetAccountSettingsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetAccountSettingsResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetAccountSettingsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -398,10 +383,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AccountApi.UpdateAccountSettingsImagesById";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/AccountApi.cs
+++ b/ShipEngineSDK/Api/AccountApi.cs
@@ -31,8 +31,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createAccountSettingsImageRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetAccountSettingsImagesResponseBody)</returns>
-    Task<GetAccountSettingsImagesResponseBody> CreateAccountImage(CreateAccountSettingsImageRequestBody createAccountSettingsImageRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetAccountSettingsImagesResponseBody)</returns>
+    Task<ShipEngineResponse<GetAccountSettingsImagesResponseBody>> CreateAccountImage(CreateAccountSettingsImageRequestBody createAccountSettingsImageRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create an Account Image Create an Account Image
@@ -42,8 +42,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createAccountSettingsImageRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetAccountSettingsImagesResponseBody)</returns>
-    Task<GetAccountSettingsImagesResponseBody> CreateAccountImage(HttpClient methodClient, CreateAccountSettingsImageRequestBody createAccountSettingsImageRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetAccountSettingsImagesResponseBody)</returns>
+    Task<ShipEngineResponse<GetAccountSettingsImagesResponseBody>> CreateAccountImage(HttpClient methodClient, CreateAccountSettingsImageRequestBody createAccountSettingsImageRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete Account Image By Id Delete Account Image By Id
@@ -52,8 +52,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="labelImageId">Label Image Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DeleteAccountImageById(string labelImageId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DeleteAccountImageById(string labelImageId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete Account Image By Id Delete Account Image By Id
@@ -63,8 +63,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="labelImageId">Label Image Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DeleteAccountImageById(HttpClient methodClient, string labelImageId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DeleteAccountImageById(HttpClient methodClient, string labelImageId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Account Image By ID Retrieve information for an account image.
@@ -73,8 +73,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="labelImageId">Label Image Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetAccountSettingsImagesResponseBody)</returns>
-    Task<GetAccountSettingsImagesResponseBody> GetAccountSettingsImagesById(string labelImageId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetAccountSettingsImagesResponseBody)</returns>
+    Task<ShipEngineResponse<GetAccountSettingsImagesResponseBody>> GetAccountSettingsImagesById(string labelImageId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Account Image By ID Retrieve information for an account image.
@@ -84,8 +84,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="labelImageId">Label Image Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetAccountSettingsImagesResponseBody)</returns>
-    Task<GetAccountSettingsImagesResponseBody> GetAccountSettingsImagesById(HttpClient methodClient, string labelImageId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetAccountSettingsImagesResponseBody)</returns>
+    Task<ShipEngineResponse<GetAccountSettingsImagesResponseBody>> GetAccountSettingsImagesById(HttpClient methodClient, string labelImageId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Account Images List all account images for the ShipEngine account
@@ -93,8 +93,8 @@ public partial interface IShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListAccountSettingsImagesResponseBody)</returns>
-    Task<ListAccountSettingsImagesResponseBody> ListAccountImages(CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListAccountSettingsImagesResponseBody)</returns>
+    Task<ShipEngineResponse<ListAccountSettingsImagesResponseBody>> ListAccountImages(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Account Images List all account images for the ShipEngine account
@@ -103,8 +103,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListAccountSettingsImagesResponseBody)</returns>
-    Task<ListAccountSettingsImagesResponseBody> ListAccountImages(HttpClient methodClient, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListAccountSettingsImagesResponseBody)</returns>
+    Task<ShipEngineResponse<ListAccountSettingsImagesResponseBody>> ListAccountImages(HttpClient methodClient, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Account Settings List all account settings for the ShipEngine account
@@ -112,8 +112,8 @@ public partial interface IShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetAccountSettingsResponseBody)</returns>
-    Task<GetAccountSettingsResponseBody> ListAccountSettings(CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetAccountSettingsResponseBody)</returns>
+    Task<ShipEngineResponse<GetAccountSettingsResponseBody>> ListAccountSettings(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Account Settings List all account settings for the ShipEngine account
@@ -122,8 +122,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetAccountSettingsResponseBody)</returns>
-    Task<GetAccountSettingsResponseBody> ListAccountSettings(HttpClient methodClient, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetAccountSettingsResponseBody)</returns>
+    Task<ShipEngineResponse<GetAccountSettingsResponseBody>> ListAccountSettings(HttpClient methodClient, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Account Image By ID Update information for an account image.
@@ -133,8 +133,8 @@ public partial interface IShipEngine
     /// <param name="updateAccountSettingsImageRequestBody"></param>
     /// <param name="labelImageId">Label Image Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdateAccountSettingsImagesById(UpdateAccountSettingsImageRequestBody updateAccountSettingsImageRequestBody, string labelImageId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdateAccountSettingsImagesById(UpdateAccountSettingsImageRequestBody updateAccountSettingsImageRequestBody, string labelImageId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Account Image By ID Update information for an account image.
@@ -145,8 +145,8 @@ public partial interface IShipEngine
     /// <param name="updateAccountSettingsImageRequestBody"></param>
     /// <param name="labelImageId">Label Image Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdateAccountSettingsImagesById(HttpClient methodClient, UpdateAccountSettingsImageRequestBody updateAccountSettingsImageRequestBody, string labelImageId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdateAccountSettingsImagesById(HttpClient methodClient, UpdateAccountSettingsImageRequestBody updateAccountSettingsImageRequestBody, string labelImageId, CancellationToken cancellationToken = default);
 
 }
 
@@ -162,8 +162,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createAccountSettingsImageRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetAccountSettingsImagesResponseBody)</returns>
-    public Task<GetAccountSettingsImagesResponseBody> CreateAccountImage(CreateAccountSettingsImageRequestBody createAccountSettingsImageRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetAccountSettingsImagesResponseBody)</returns>
+    public Task<ShipEngineResponse<GetAccountSettingsImagesResponseBody>> CreateAccountImage(CreateAccountSettingsImageRequestBody createAccountSettingsImageRequestBody, CancellationToken cancellationToken = default)
     {
         return CreateAccountImage(_client, createAccountSettingsImageRequestBody, cancellationToken);
     }
@@ -176,8 +176,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createAccountSettingsImageRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetAccountSettingsImagesResponseBody)</returns>
-    public async Task<GetAccountSettingsImagesResponseBody> CreateAccountImage(HttpClient methodClient, CreateAccountSettingsImageRequestBody createAccountSettingsImageRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetAccountSettingsImagesResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetAccountSettingsImagesResponseBody>> CreateAccountImage(HttpClient methodClient, CreateAccountSettingsImageRequestBody createAccountSettingsImageRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'createAccountSettingsImageRequestBody' is set
         if (createAccountSettingsImageRequestBody == null)
@@ -192,9 +192,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AccountApi.CreateAccountImage";
 
-        var result = await SendHttpRequestAsync<GetAccountSettingsImagesResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetAccountSettingsImagesResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetAccountSettingsImagesResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -204,8 +205,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="labelImageId">Label Image Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> DeleteAccountImageById(string labelImageId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> DeleteAccountImageById(string labelImageId, CancellationToken cancellationToken = default)
     {
         return DeleteAccountImageById(_client, labelImageId, cancellationToken);
     }
@@ -218,8 +219,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="labelImageId">Label Image Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> DeleteAccountImageById(HttpClient methodClient, string labelImageId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> DeleteAccountImageById(HttpClient methodClient, string labelImageId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'labelImageId' is set
         if (labelImageId == null)
@@ -234,9 +235,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AccountApi.DeleteAccountImageById";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Delete, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -246,8 +248,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="labelImageId">Label Image Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetAccountSettingsImagesResponseBody)</returns>
-    public Task<GetAccountSettingsImagesResponseBody> GetAccountSettingsImagesById(string labelImageId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetAccountSettingsImagesResponseBody)</returns>
+    public Task<ShipEngineResponse<GetAccountSettingsImagesResponseBody>> GetAccountSettingsImagesById(string labelImageId, CancellationToken cancellationToken = default)
     {
         return GetAccountSettingsImagesById(_client, labelImageId, cancellationToken);
     }
@@ -260,8 +262,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="labelImageId">Label Image Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetAccountSettingsImagesResponseBody)</returns>
-    public async Task<GetAccountSettingsImagesResponseBody> GetAccountSettingsImagesById(HttpClient methodClient, string labelImageId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetAccountSettingsImagesResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetAccountSettingsImagesResponseBody>> GetAccountSettingsImagesById(HttpClient methodClient, string labelImageId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'labelImageId' is set
         if (labelImageId == null)
@@ -276,9 +278,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AccountApi.GetAccountSettingsImagesById";
 
-        var result = await SendHttpRequestAsync<GetAccountSettingsImagesResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetAccountSettingsImagesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetAccountSettingsImagesResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -287,8 +290,8 @@ public partial class ShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListAccountSettingsImagesResponseBody)</returns>
-    public Task<ListAccountSettingsImagesResponseBody> ListAccountImages(CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListAccountSettingsImagesResponseBody)</returns>
+    public Task<ShipEngineResponse<ListAccountSettingsImagesResponseBody>> ListAccountImages(CancellationToken cancellationToken = default)
     {
         return ListAccountImages(_client, cancellationToken);
     }
@@ -300,8 +303,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListAccountSettingsImagesResponseBody)</returns>
-    public async Task<ListAccountSettingsImagesResponseBody> ListAccountImages(HttpClient methodClient, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListAccountSettingsImagesResponseBody)</returns>
+    public async Task<ShipEngineResponse<ListAccountSettingsImagesResponseBody>> ListAccountImages(HttpClient methodClient, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/account/settings/images");
@@ -309,9 +312,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AccountApi.ListAccountImages";
 
-        var result = await SendHttpRequestAsync<ListAccountSettingsImagesResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ListAccountSettingsImagesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ListAccountSettingsImagesResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -320,8 +324,8 @@ public partial class ShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetAccountSettingsResponseBody)</returns>
-    public Task<GetAccountSettingsResponseBody> ListAccountSettings(CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetAccountSettingsResponseBody)</returns>
+    public Task<ShipEngineResponse<GetAccountSettingsResponseBody>> ListAccountSettings(CancellationToken cancellationToken = default)
     {
         return ListAccountSettings(_client, cancellationToken);
     }
@@ -333,8 +337,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetAccountSettingsResponseBody)</returns>
-    public async Task<GetAccountSettingsResponseBody> ListAccountSettings(HttpClient methodClient, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetAccountSettingsResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetAccountSettingsResponseBody>> ListAccountSettings(HttpClient methodClient, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/account/settings");
@@ -342,9 +346,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AccountApi.ListAccountSettings";
 
-        var result = await SendHttpRequestAsync<GetAccountSettingsResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetAccountSettingsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetAccountSettingsResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -355,8 +360,8 @@ public partial class ShipEngine
     /// <param name="updateAccountSettingsImageRequestBody"></param>
     /// <param name="labelImageId">Label Image Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> UpdateAccountSettingsImagesById(UpdateAccountSettingsImageRequestBody updateAccountSettingsImageRequestBody, string labelImageId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> UpdateAccountSettingsImagesById(UpdateAccountSettingsImageRequestBody updateAccountSettingsImageRequestBody, string labelImageId, CancellationToken cancellationToken = default)
     {
         return UpdateAccountSettingsImagesById(_client, updateAccountSettingsImageRequestBody, labelImageId, cancellationToken);
     }
@@ -370,8 +375,8 @@ public partial class ShipEngine
     /// <param name="updateAccountSettingsImageRequestBody"></param>
     /// <param name="labelImageId">Label Image Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> UpdateAccountSettingsImagesById(HttpClient methodClient, UpdateAccountSettingsImageRequestBody updateAccountSettingsImageRequestBody, string labelImageId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> UpdateAccountSettingsImagesById(HttpClient methodClient, UpdateAccountSettingsImageRequestBody updateAccountSettingsImageRequestBody, string labelImageId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'updateAccountSettingsImageRequestBody' is set
         if (updateAccountSettingsImageRequestBody == null)
@@ -393,9 +398,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AccountApi.UpdateAccountSettingsImagesById";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/AddressesApi.cs
+++ b/ShipEngineSDK/Api/AddressesApi.cs
@@ -31,8 +31,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="parseAddressRequestBody">The only required field is &#x60;text&#x60;, which is the text to be parsed. You can optionally also provide an &#x60;address&#x60; containing already-known values. For example, you may already know the recipient&#39;s name, city, and country, and only want to parse the street address into separate lines. </param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ParseAddressResponseBody)</returns>
-    Task<ParseAddressResponseBody> ParseAddress(ParseAddressRequestBody parseAddressRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ParseAddressResponseBody)</returns>
+    Task<ShipEngineResponse<ParseAddressResponseBody>> ParseAddress(ParseAddressRequestBody parseAddressRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Parse an address The address-recognition API makes it easy for you to extract address data from unstructured text, including the recipient name, line 1, line 2, city, postal code, and more.  Data often enters your system as unstructured text (for example: emails, SMS messages, support tickets, or other documents). ShipEngine&#39;s address-recognition API helps you extract meaningful, structured data from this unstructured text. The parsed address data is returned in the same structure that&#39;s used for other ShipEngine APIs, such as address validation, rate quotes, and shipping labels.  &gt; **Note:** Address recognition is currently supported for the United States, Canada, Australia, New Zealand, the United Kingdom, and Ireland. 
@@ -42,8 +42,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="parseAddressRequestBody">The only required field is &#x60;text&#x60;, which is the text to be parsed. You can optionally also provide an &#x60;address&#x60; containing already-known values. For example, you may already know the recipient&#39;s name, city, and country, and only want to parse the street address into separate lines. </param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ParseAddressResponseBody)</returns>
-    Task<ParseAddressResponseBody> ParseAddress(HttpClient methodClient, ParseAddressRequestBody parseAddressRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ParseAddressResponseBody)</returns>
+    Task<ShipEngineResponse<ParseAddressResponseBody>> ParseAddress(HttpClient methodClient, ParseAddressRequestBody parseAddressRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Validate An Address Address validation ensures accurate addresses and can lead to reduced shipping costs by preventing address correction surcharges. ShipEngine cross references multiple databases to validate addresses and identify potential deliverability issues. 
@@ -52,8 +52,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="addressToValidate"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;AddressValidationResult&gt;)</returns>
-    Task<List<AddressValidationResult>> ValidateAddress(List<AddressToValidate> addressToValidate, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (List&lt;AddressValidationResult&gt;)</returns>
+    Task<ShipEngineResponse<List<AddressValidationResult>>> ValidateAddress(List<AddressToValidate> addressToValidate, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Validate An Address Address validation ensures accurate addresses and can lead to reduced shipping costs by preventing address correction surcharges. ShipEngine cross references multiple databases to validate addresses and identify potential deliverability issues. 
@@ -63,8 +63,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="addressToValidate"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;AddressValidationResult&gt;)</returns>
-    Task<List<AddressValidationResult>> ValidateAddress(HttpClient methodClient, List<AddressToValidate> addressToValidate, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (List&lt;AddressValidationResult&gt;)</returns>
+    Task<ShipEngineResponse<List<AddressValidationResult>>> ValidateAddress(HttpClient methodClient, List<AddressToValidate> addressToValidate, CancellationToken cancellationToken = default);
 
 }
 
@@ -80,8 +80,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="parseAddressRequestBody">The only required field is &#x60;text&#x60;, which is the text to be parsed. You can optionally also provide an &#x60;address&#x60; containing already-known values. For example, you may already know the recipient&#39;s name, city, and country, and only want to parse the street address into separate lines. </param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ParseAddressResponseBody)</returns>
-    public Task<ParseAddressResponseBody> ParseAddress(ParseAddressRequestBody parseAddressRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ParseAddressResponseBody)</returns>
+    public Task<ShipEngineResponse<ParseAddressResponseBody>> ParseAddress(ParseAddressRequestBody parseAddressRequestBody, CancellationToken cancellationToken = default)
     {
         return ParseAddress(_client, parseAddressRequestBody, cancellationToken);
     }
@@ -94,8 +94,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="parseAddressRequestBody">The only required field is &#x60;text&#x60;, which is the text to be parsed. You can optionally also provide an &#x60;address&#x60; containing already-known values. For example, you may already know the recipient&#39;s name, city, and country, and only want to parse the street address into separate lines. </param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ParseAddressResponseBody)</returns>
-    public async Task<ParseAddressResponseBody> ParseAddress(HttpClient methodClient, ParseAddressRequestBody parseAddressRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ParseAddressResponseBody)</returns>
+    public async Task<ShipEngineResponse<ParseAddressResponseBody>> ParseAddress(HttpClient methodClient, ParseAddressRequestBody parseAddressRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'parseAddressRequestBody' is set
         if (parseAddressRequestBody == null)
@@ -110,9 +110,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AddressesApi.ParseAddress";
 
-        var result = await SendHttpRequestAsync<ParseAddressResponseBody>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ParseAddressResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ParseAddressResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -122,8 +123,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="addressToValidate"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;AddressValidationResult&gt;)</returns>
-    public Task<List<AddressValidationResult>> ValidateAddress(List<AddressToValidate> addressToValidate, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (List&lt;AddressValidationResult&gt;)</returns>
+    public Task<ShipEngineResponse<List<AddressValidationResult>>> ValidateAddress(List<AddressToValidate> addressToValidate, CancellationToken cancellationToken = default)
     {
         return ValidateAddress(_client, addressToValidate, cancellationToken);
     }
@@ -136,8 +137,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="addressToValidate"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;AddressValidationResult&gt;)</returns>
-    public async Task<List<AddressValidationResult>> ValidateAddress(HttpClient methodClient, List<AddressToValidate> addressToValidate, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (List&lt;AddressValidationResult&gt;)</returns>
+    public async Task<ShipEngineResponse<List<AddressValidationResult>>> ValidateAddress(HttpClient methodClient, List<AddressToValidate> addressToValidate, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'addressToValidate' is set
         if (addressToValidate == null)
@@ -152,9 +153,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AddressesApi.ValidateAddress";
 
-        var result = await SendHttpRequestAsync<List<AddressValidationResult>>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<List<AddressValidationResult>>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<List<AddressValidationResult>>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/AddressesApi.cs
+++ b/ShipEngineSDK/Api/AddressesApi.cs
@@ -110,10 +110,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AddressesApi.ParseAddress";
 
-        var (data, response) = await GetHttpResponse<ParseAddressResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ParseAddressResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ParseAddressResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -153,10 +150,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "AddressesApi.ValidateAddress";
 
-        var (data, response) = await GetHttpResponse<List<AddressValidationResult>>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<List<AddressValidationResult>>(data, response.StatusCode, headers);
+        return await GetHttpResponse<List<AddressValidationResult>>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/BatchesApi.cs
+++ b/ShipEngineSDK/Api/BatchesApi.cs
@@ -307,10 +307,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.AddToBatch";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -350,10 +347,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.CreateBatch";
 
-        var (data, response) = await GetHttpResponse<CreateBatchResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<CreateBatchResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<CreateBatchResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -393,10 +387,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.DeleteBatch";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -436,10 +427,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.GetBatchByExternalId";
 
-        var (data, response) = await GetHttpResponse<GetBatchByExternalIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetBatchByExternalIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetBatchByExternalIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -479,10 +467,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.GetBatchById";
 
-        var (data, response) = await GetHttpResponse<GetBatchByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetBatchByIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetBatchByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -534,10 +519,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.ListBatchErrors";
 
-        var (data, response) = await GetHttpResponse<ListBatchErrorsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ListBatchErrorsResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ListBatchErrorsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -604,10 +586,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.ListBatches";
 
-        var (data, response) = await GetHttpResponse<ListBatchesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ListBatchesResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ListBatchesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -656,10 +635,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.ProcessBatch";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -708,10 +684,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.RemoveFromBatch";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -751,10 +724,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.UpdateBatch";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/BatchesApi.cs
+++ b/ShipEngineSDK/Api/BatchesApi.cs
@@ -32,8 +32,8 @@ public partial interface IShipEngine
     /// <param name="addToBatchRequestBody"></param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> AddToBatch(AddToBatchRequestBody addToBatchRequestBody, string batchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> AddToBatch(AddToBatchRequestBody addToBatchRequestBody, string batchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Add to a Batch Add a Shipment or Rate to a Batch
@@ -44,8 +44,8 @@ public partial interface IShipEngine
     /// <param name="addToBatchRequestBody"></param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> AddToBatch(HttpClient methodClient, AddToBatchRequestBody addToBatchRequestBody, string batchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> AddToBatch(HttpClient methodClient, AddToBatchRequestBody addToBatchRequestBody, string batchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create A Batch Create a Batch
@@ -54,8 +54,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createBatchRequest"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateBatchResponseBody)</returns>
-    Task<CreateBatchResponseBody> CreateBatch(CreateBatchRequest createBatchRequest, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateBatchResponseBody)</returns>
+    Task<ShipEngineResponse<CreateBatchResponseBody>> CreateBatch(CreateBatchRequest createBatchRequest, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create A Batch Create a Batch
@@ -65,8 +65,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createBatchRequest"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateBatchResponseBody)</returns>
-    Task<CreateBatchResponseBody> CreateBatch(HttpClient methodClient, CreateBatchRequest createBatchRequest, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateBatchResponseBody)</returns>
+    Task<ShipEngineResponse<CreateBatchResponseBody>> CreateBatch(HttpClient methodClient, CreateBatchRequest createBatchRequest, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete Batch By Id Delete Batch By Id
@@ -75,8 +75,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DeleteBatch(string batchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DeleteBatch(string batchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete Batch By Id Delete Batch By Id
@@ -86,8 +86,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DeleteBatch(HttpClient methodClient, string batchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DeleteBatch(HttpClient methodClient, string batchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Batch By External ID Get Batch By External ID
@@ -96,8 +96,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="externalBatchId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetBatchByExternalIdResponseBody)</returns>
-    Task<GetBatchByExternalIdResponseBody> GetBatchByExternalId(string externalBatchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetBatchByExternalIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetBatchByExternalIdResponseBody>> GetBatchByExternalId(string externalBatchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Batch By External ID Get Batch By External ID
@@ -107,8 +107,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="externalBatchId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetBatchByExternalIdResponseBody)</returns>
-    Task<GetBatchByExternalIdResponseBody> GetBatchByExternalId(HttpClient methodClient, string externalBatchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetBatchByExternalIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetBatchByExternalIdResponseBody>> GetBatchByExternalId(HttpClient methodClient, string externalBatchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Batch By ID Get Batch By ID
@@ -117,8 +117,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetBatchByIdResponseBody)</returns>
-    Task<GetBatchByIdResponseBody> GetBatchById(string batchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetBatchByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetBatchByIdResponseBody>> GetBatchById(string batchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Batch By ID Get Batch By ID
@@ -128,8 +128,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetBatchByIdResponseBody)</returns>
-    Task<GetBatchByIdResponseBody> GetBatchById(HttpClient methodClient, string batchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetBatchByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetBatchByIdResponseBody>> GetBatchById(HttpClient methodClient, string batchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Batch Errors Error handling in batches are handled differently than in a single synchronous request. You must retrieve the status of your batch by [getting a batch](https://www.shipengine.com/docs/reference/get-batch-by-id/) and getting an overview of the statuses or you can list errors directly here below to get detailed information about the errors. 
@@ -140,8 +140,8 @@ public partial interface IShipEngine
     /// <param name="pagesize"> (optional)</param>
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListBatchErrorsResponseBody)</returns>
-    Task<ListBatchErrorsResponseBody> ListBatchErrors(string batchId, int? pagesize, int? page, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListBatchErrorsResponseBody)</returns>
+    Task<ShipEngineResponse<ListBatchErrorsResponseBody>> ListBatchErrors(string batchId, int? pagesize, int? page, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Batch Errors Error handling in batches are handled differently than in a single synchronous request. You must retrieve the status of your batch by [getting a batch](https://www.shipengine.com/docs/reference/get-batch-by-id/) and getting an overview of the statuses or you can list errors directly here below to get detailed information about the errors. 
@@ -153,8 +153,8 @@ public partial interface IShipEngine
     /// <param name="pagesize"> (optional)</param>
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListBatchErrorsResponseBody)</returns>
-    Task<ListBatchErrorsResponseBody> ListBatchErrors(HttpClient methodClient, string batchId, int? pagesize, int? page, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListBatchErrorsResponseBody)</returns>
+    Task<ShipEngineResponse<ListBatchErrorsResponseBody>> ListBatchErrors(HttpClient methodClient, string batchId, int? pagesize, int? page, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Batches List Batches associated with your Shipengine account
@@ -168,8 +168,8 @@ public partial interface IShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListBatchesResponseBody)</returns>
-    Task<ListBatchesResponseBody> ListBatches(BatchStatus? status, BatchesSortBy? sortBy, SortDir? sortDir, string? batchNumber, int? page, int? pageSize, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListBatchesResponseBody)</returns>
+    Task<ShipEngineResponse<ListBatchesResponseBody>> ListBatches(BatchStatus? status, BatchesSortBy? sortBy, SortDir? sortDir, string? batchNumber, int? page, int? pageSize, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Batches List Batches associated with your Shipengine account
@@ -184,8 +184,8 @@ public partial interface IShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListBatchesResponseBody)</returns>
-    Task<ListBatchesResponseBody> ListBatches(HttpClient methodClient, BatchStatus? status, BatchesSortBy? sortBy, SortDir? sortDir, string? batchNumber, int? page, int? pageSize, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListBatchesResponseBody)</returns>
+    Task<ShipEngineResponse<ListBatchesResponseBody>> ListBatches(HttpClient methodClient, BatchStatus? status, BatchesSortBy? sortBy, SortDir? sortDir, string? batchNumber, int? page, int? pageSize, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Process Batch ID Labels Process Batch ID Labels
@@ -195,8 +195,8 @@ public partial interface IShipEngine
     /// <param name="processBatchRequestBody"></param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> ProcessBatch(ProcessBatchRequestBody processBatchRequestBody, string batchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> ProcessBatch(ProcessBatchRequestBody processBatchRequestBody, string batchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Process Batch ID Labels Process Batch ID Labels
@@ -207,8 +207,8 @@ public partial interface IShipEngine
     /// <param name="processBatchRequestBody"></param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> ProcessBatch(HttpClient methodClient, ProcessBatchRequestBody processBatchRequestBody, string batchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> ProcessBatch(HttpClient methodClient, ProcessBatchRequestBody processBatchRequestBody, string batchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Remove From Batch Remove a shipment or rate from a batch
@@ -218,8 +218,8 @@ public partial interface IShipEngine
     /// <param name="removeFromBatchRequestBody"></param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> RemoveFromBatch(RemoveFromBatchRequestBody removeFromBatchRequestBody, string batchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> RemoveFromBatch(RemoveFromBatchRequestBody removeFromBatchRequestBody, string batchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Remove From Batch Remove a shipment or rate from a batch
@@ -230,8 +230,8 @@ public partial interface IShipEngine
     /// <param name="removeFromBatchRequestBody"></param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> RemoveFromBatch(HttpClient methodClient, RemoveFromBatchRequestBody removeFromBatchRequestBody, string batchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> RemoveFromBatch(HttpClient methodClient, RemoveFromBatchRequestBody removeFromBatchRequestBody, string batchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Batch By Id Update Batch By Id
@@ -240,8 +240,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdateBatch(string batchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdateBatch(string batchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Batch By Id Update Batch By Id
@@ -251,8 +251,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdateBatch(HttpClient methodClient, string batchId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdateBatch(HttpClient methodClient, string batchId, CancellationToken cancellationToken = default);
 
 }
 
@@ -269,8 +269,8 @@ public partial class ShipEngine
     /// <param name="addToBatchRequestBody"></param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> AddToBatch(AddToBatchRequestBody addToBatchRequestBody, string batchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> AddToBatch(AddToBatchRequestBody addToBatchRequestBody, string batchId, CancellationToken cancellationToken = default)
     {
         return AddToBatch(_client, addToBatchRequestBody, batchId, cancellationToken);
     }
@@ -284,8 +284,8 @@ public partial class ShipEngine
     /// <param name="addToBatchRequestBody"></param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> AddToBatch(HttpClient methodClient, AddToBatchRequestBody addToBatchRequestBody, string batchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> AddToBatch(HttpClient methodClient, AddToBatchRequestBody addToBatchRequestBody, string batchId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'addToBatchRequestBody' is set
         if (addToBatchRequestBody == null)
@@ -307,9 +307,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.AddToBatch";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -319,8 +320,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createBatchRequest"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateBatchResponseBody)</returns>
-    public Task<CreateBatchResponseBody> CreateBatch(CreateBatchRequest createBatchRequest, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateBatchResponseBody)</returns>
+    public Task<ShipEngineResponse<CreateBatchResponseBody>> CreateBatch(CreateBatchRequest createBatchRequest, CancellationToken cancellationToken = default)
     {
         return CreateBatch(_client, createBatchRequest, cancellationToken);
     }
@@ -333,8 +334,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createBatchRequest"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateBatchResponseBody)</returns>
-    public async Task<CreateBatchResponseBody> CreateBatch(HttpClient methodClient, CreateBatchRequest createBatchRequest, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateBatchResponseBody)</returns>
+    public async Task<ShipEngineResponse<CreateBatchResponseBody>> CreateBatch(HttpClient methodClient, CreateBatchRequest createBatchRequest, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'createBatchRequest' is set
         if (createBatchRequest == null)
@@ -349,9 +350,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.CreateBatch";
 
-        var result = await SendHttpRequestAsync<CreateBatchResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<CreateBatchResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<CreateBatchResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -361,8 +363,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> DeleteBatch(string batchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> DeleteBatch(string batchId, CancellationToken cancellationToken = default)
     {
         return DeleteBatch(_client, batchId, cancellationToken);
     }
@@ -375,8 +377,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> DeleteBatch(HttpClient methodClient, string batchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> DeleteBatch(HttpClient methodClient, string batchId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'batchId' is set
         if (batchId == null)
@@ -391,9 +393,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.DeleteBatch";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Delete, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -403,8 +406,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="externalBatchId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetBatchByExternalIdResponseBody)</returns>
-    public Task<GetBatchByExternalIdResponseBody> GetBatchByExternalId(string externalBatchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetBatchByExternalIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetBatchByExternalIdResponseBody>> GetBatchByExternalId(string externalBatchId, CancellationToken cancellationToken = default)
     {
         return GetBatchByExternalId(_client, externalBatchId, cancellationToken);
     }
@@ -417,8 +420,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="externalBatchId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetBatchByExternalIdResponseBody)</returns>
-    public async Task<GetBatchByExternalIdResponseBody> GetBatchByExternalId(HttpClient methodClient, string externalBatchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetBatchByExternalIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetBatchByExternalIdResponseBody>> GetBatchByExternalId(HttpClient methodClient, string externalBatchId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'externalBatchId' is set
         if (externalBatchId == null)
@@ -433,9 +436,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.GetBatchByExternalId";
 
-        var result = await SendHttpRequestAsync<GetBatchByExternalIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetBatchByExternalIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetBatchByExternalIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -445,8 +449,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetBatchByIdResponseBody)</returns>
-    public Task<GetBatchByIdResponseBody> GetBatchById(string batchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetBatchByIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetBatchByIdResponseBody>> GetBatchById(string batchId, CancellationToken cancellationToken = default)
     {
         return GetBatchById(_client, batchId, cancellationToken);
     }
@@ -459,8 +463,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetBatchByIdResponseBody)</returns>
-    public async Task<GetBatchByIdResponseBody> GetBatchById(HttpClient methodClient, string batchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetBatchByIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetBatchByIdResponseBody>> GetBatchById(HttpClient methodClient, string batchId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'batchId' is set
         if (batchId == null)
@@ -475,9 +479,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.GetBatchById";
 
-        var result = await SendHttpRequestAsync<GetBatchByIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetBatchByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetBatchByIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -489,8 +494,8 @@ public partial class ShipEngine
     /// <param name="pagesize"> (optional)</param>
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListBatchErrorsResponseBody)</returns>
-    public Task<ListBatchErrorsResponseBody> ListBatchErrors(string batchId, int? pagesize = default, int? page = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListBatchErrorsResponseBody)</returns>
+    public Task<ShipEngineResponse<ListBatchErrorsResponseBody>> ListBatchErrors(string batchId, int? pagesize = default, int? page = default, CancellationToken cancellationToken = default)
     {
         return ListBatchErrors(_client, batchId, pagesize, page, cancellationToken);
     }
@@ -505,8 +510,8 @@ public partial class ShipEngine
     /// <param name="pagesize"> (optional)</param>
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListBatchErrorsResponseBody)</returns>
-    public async Task<ListBatchErrorsResponseBody> ListBatchErrors(HttpClient methodClient, string batchId, int? pagesize = default, int? page = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListBatchErrorsResponseBody)</returns>
+    public async Task<ShipEngineResponse<ListBatchErrorsResponseBody>> ListBatchErrors(HttpClient methodClient, string batchId, int? pagesize = default, int? page = default, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'batchId' is set
         if (batchId == null)
@@ -529,9 +534,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.ListBatchErrors";
 
-        var result = await SendHttpRequestAsync<ListBatchErrorsResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ListBatchErrorsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ListBatchErrorsResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -546,8 +552,8 @@ public partial class ShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListBatchesResponseBody)</returns>
-    public Task<ListBatchesResponseBody> ListBatches(BatchStatus? status = default, BatchesSortBy? sortBy = default, SortDir? sortDir = default, string? batchNumber = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListBatchesResponseBody)</returns>
+    public Task<ShipEngineResponse<ListBatchesResponseBody>> ListBatches(BatchStatus? status = default, BatchesSortBy? sortBy = default, SortDir? sortDir = default, string? batchNumber = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
     {
         return ListBatches(_client, status, sortBy, sortDir, batchNumber, page, pageSize, cancellationToken);
     }
@@ -565,8 +571,8 @@ public partial class ShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListBatchesResponseBody)</returns>
-    public async Task<ListBatchesResponseBody> ListBatches(HttpClient methodClient, BatchStatus? status = default, BatchesSortBy? sortBy = default, SortDir? sortDir = default, string? batchNumber = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListBatchesResponseBody)</returns>
+    public async Task<ShipEngineResponse<ListBatchesResponseBody>> ListBatches(HttpClient methodClient, BatchStatus? status = default, BatchesSortBy? sortBy = default, SortDir? sortDir = default, string? batchNumber = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/batches");
@@ -598,9 +604,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.ListBatches";
 
-        var result = await SendHttpRequestAsync<ListBatchesResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ListBatchesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ListBatchesResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -611,8 +618,8 @@ public partial class ShipEngine
     /// <param name="processBatchRequestBody"></param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> ProcessBatch(ProcessBatchRequestBody processBatchRequestBody, string batchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> ProcessBatch(ProcessBatchRequestBody processBatchRequestBody, string batchId, CancellationToken cancellationToken = default)
     {
         return ProcessBatch(_client, processBatchRequestBody, batchId, cancellationToken);
     }
@@ -626,8 +633,8 @@ public partial class ShipEngine
     /// <param name="processBatchRequestBody"></param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> ProcessBatch(HttpClient methodClient, ProcessBatchRequestBody processBatchRequestBody, string batchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> ProcessBatch(HttpClient methodClient, ProcessBatchRequestBody processBatchRequestBody, string batchId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'processBatchRequestBody' is set
         if (processBatchRequestBody == null)
@@ -649,9 +656,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.ProcessBatch";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -662,8 +670,8 @@ public partial class ShipEngine
     /// <param name="removeFromBatchRequestBody"></param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> RemoveFromBatch(RemoveFromBatchRequestBody removeFromBatchRequestBody, string batchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> RemoveFromBatch(RemoveFromBatchRequestBody removeFromBatchRequestBody, string batchId, CancellationToken cancellationToken = default)
     {
         return RemoveFromBatch(_client, removeFromBatchRequestBody, batchId, cancellationToken);
     }
@@ -677,8 +685,8 @@ public partial class ShipEngine
     /// <param name="removeFromBatchRequestBody"></param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> RemoveFromBatch(HttpClient methodClient, RemoveFromBatchRequestBody removeFromBatchRequestBody, string batchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> RemoveFromBatch(HttpClient methodClient, RemoveFromBatchRequestBody removeFromBatchRequestBody, string batchId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'removeFromBatchRequestBody' is set
         if (removeFromBatchRequestBody == null)
@@ -700,9 +708,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.RemoveFromBatch";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -712,8 +721,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> UpdateBatch(string batchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> UpdateBatch(string batchId, CancellationToken cancellationToken = default)
     {
         return UpdateBatch(_client, batchId, cancellationToken);
     }
@@ -726,8 +735,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="batchId">Batch ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> UpdateBatch(HttpClient methodClient, string batchId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> UpdateBatch(HttpClient methodClient, string batchId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'batchId' is set
         if (batchId == null)
@@ -742,9 +751,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "BatchesApi.UpdateBatch";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/CarrierAccountsApi.cs
+++ b/ShipEngineSDK/Api/CarrierAccountsApi.cs
@@ -171,10 +171,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarrierAccountsApi.ConnectCarrier";
 
-        var (data, response) = await GetHttpResponse<ConnectCarrierResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ConnectCarrierResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ConnectCarrierResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -223,10 +220,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarrierAccountsApi.DisconnectCarrier";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -275,10 +269,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarrierAccountsApi.GetCarrierSettings";
 
-        var (data, response) = await GetHttpResponse<GetCarrierSettingsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetCarrierSettingsResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetCarrierSettingsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -336,10 +327,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarrierAccountsApi.UpdateCarrierSettings";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/CarrierAccountsApi.cs
+++ b/ShipEngineSDK/Api/CarrierAccountsApi.cs
@@ -32,8 +32,8 @@ public partial interface IShipEngine
     /// <param name="carrierName">The carrier name, such as &#x60;stamps_com&#x60;, &#x60;ups&#x60;, &#x60;fedex&#x60;, or &#x60;dhl_express&#x60;.</param>
     /// <param name="connectCarrierRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ConnectCarrierResponseBody)</returns>
-    Task<ConnectCarrierResponseBody> ConnectCarrier(CarrierName carrierName, ConnectCarrierRequestBody connectCarrierRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ConnectCarrierResponseBody)</returns>
+    Task<ShipEngineResponse<ConnectCarrierResponseBody>> ConnectCarrier(CarrierName carrierName, ConnectCarrierRequestBody connectCarrierRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Connect a carrier account Connect a carrier account
@@ -44,8 +44,8 @@ public partial interface IShipEngine
     /// <param name="carrierName">The carrier name, such as &#x60;stamps_com&#x60;, &#x60;ups&#x60;, &#x60;fedex&#x60;, or &#x60;dhl_express&#x60;.</param>
     /// <param name="connectCarrierRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ConnectCarrierResponseBody)</returns>
-    Task<ConnectCarrierResponseBody> ConnectCarrier(HttpClient methodClient, CarrierName carrierName, ConnectCarrierRequestBody connectCarrierRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ConnectCarrierResponseBody)</returns>
+    Task<ShipEngineResponse<ConnectCarrierResponseBody>> ConnectCarrier(HttpClient methodClient, CarrierName carrierName, ConnectCarrierRequestBody connectCarrierRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Disconnect a carrier Disconnect a carrier
@@ -55,8 +55,8 @@ public partial interface IShipEngine
     /// <param name="carrierName">The carrier name, such as &#x60;stamps_com&#x60;, &#x60;ups&#x60;, &#x60;fedex&#x60;, or &#x60;dhl_express&#x60;.</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DisconnectCarrier(CarrierName carrierName, string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DisconnectCarrier(CarrierName carrierName, string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Disconnect a carrier Disconnect a carrier
@@ -67,8 +67,8 @@ public partial interface IShipEngine
     /// <param name="carrierName">The carrier name, such as &#x60;stamps_com&#x60;, &#x60;ups&#x60;, &#x60;fedex&#x60;, or &#x60;dhl_express&#x60;.</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DisconnectCarrier(HttpClient methodClient, CarrierName carrierName, string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DisconnectCarrier(HttpClient methodClient, CarrierName carrierName, string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get carrier settings Get carrier settings
@@ -78,8 +78,8 @@ public partial interface IShipEngine
     /// <param name="carrierName">The carrier name, such as &#x60;ups&#x60;, &#x60;fedex&#x60;, or &#x60;dhl_express&#x60;.</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarrierSettingsResponseBody)</returns>
-    Task<GetCarrierSettingsResponseBody> GetCarrierSettings(CarrierNameWithSettings carrierName, string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetCarrierSettingsResponseBody)</returns>
+    Task<ShipEngineResponse<GetCarrierSettingsResponseBody>> GetCarrierSettings(CarrierNameWithSettings carrierName, string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get carrier settings Get carrier settings
@@ -90,8 +90,8 @@ public partial interface IShipEngine
     /// <param name="carrierName">The carrier name, such as &#x60;ups&#x60;, &#x60;fedex&#x60;, or &#x60;dhl_express&#x60;.</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarrierSettingsResponseBody)</returns>
-    Task<GetCarrierSettingsResponseBody> GetCarrierSettings(HttpClient methodClient, CarrierNameWithSettings carrierName, string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetCarrierSettingsResponseBody)</returns>
+    Task<ShipEngineResponse<GetCarrierSettingsResponseBody>> GetCarrierSettings(HttpClient methodClient, CarrierNameWithSettings carrierName, string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update carrier settings Update carrier settings
@@ -102,8 +102,8 @@ public partial interface IShipEngine
     /// <param name="updateCarrierSettingsRequestBody"></param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdateCarrierSettings(CarrierNameWithSettings carrierName, UpdateCarrierSettingsRequestBody updateCarrierSettingsRequestBody, string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdateCarrierSettings(CarrierNameWithSettings carrierName, UpdateCarrierSettingsRequestBody updateCarrierSettingsRequestBody, string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update carrier settings Update carrier settings
@@ -115,8 +115,8 @@ public partial interface IShipEngine
     /// <param name="updateCarrierSettingsRequestBody"></param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdateCarrierSettings(HttpClient methodClient, CarrierNameWithSettings carrierName, UpdateCarrierSettingsRequestBody updateCarrierSettingsRequestBody, string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdateCarrierSettings(HttpClient methodClient, CarrierNameWithSettings carrierName, UpdateCarrierSettingsRequestBody updateCarrierSettingsRequestBody, string carrierId, CancellationToken cancellationToken = default);
 
 }
 
@@ -133,8 +133,8 @@ public partial class ShipEngine
     /// <param name="carrierName">The carrier name, such as &#x60;stamps_com&#x60;, &#x60;ups&#x60;, &#x60;fedex&#x60;, or &#x60;dhl_express&#x60;.</param>
     /// <param name="connectCarrierRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ConnectCarrierResponseBody)</returns>
-    public Task<ConnectCarrierResponseBody> ConnectCarrier(CarrierName carrierName, ConnectCarrierRequestBody connectCarrierRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ConnectCarrierResponseBody)</returns>
+    public Task<ShipEngineResponse<ConnectCarrierResponseBody>> ConnectCarrier(CarrierName carrierName, ConnectCarrierRequestBody connectCarrierRequestBody, CancellationToken cancellationToken = default)
     {
         return ConnectCarrier(_client, carrierName, connectCarrierRequestBody, cancellationToken);
     }
@@ -148,8 +148,8 @@ public partial class ShipEngine
     /// <param name="carrierName">The carrier name, such as &#x60;stamps_com&#x60;, &#x60;ups&#x60;, &#x60;fedex&#x60;, or &#x60;dhl_express&#x60;.</param>
     /// <param name="connectCarrierRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ConnectCarrierResponseBody)</returns>
-    public async Task<ConnectCarrierResponseBody> ConnectCarrier(HttpClient methodClient, CarrierName carrierName, ConnectCarrierRequestBody connectCarrierRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ConnectCarrierResponseBody)</returns>
+    public async Task<ShipEngineResponse<ConnectCarrierResponseBody>> ConnectCarrier(HttpClient methodClient, CarrierName carrierName, ConnectCarrierRequestBody connectCarrierRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'carrierName' is set
         if (carrierName == null)
@@ -171,9 +171,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarrierAccountsApi.ConnectCarrier";
 
-        var result = await SendHttpRequestAsync<ConnectCarrierResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ConnectCarrierResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ConnectCarrierResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -184,8 +185,8 @@ public partial class ShipEngine
     /// <param name="carrierName">The carrier name, such as &#x60;stamps_com&#x60;, &#x60;ups&#x60;, &#x60;fedex&#x60;, or &#x60;dhl_express&#x60;.</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> DisconnectCarrier(CarrierName carrierName, string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> DisconnectCarrier(CarrierName carrierName, string carrierId, CancellationToken cancellationToken = default)
     {
         return DisconnectCarrier(_client, carrierName, carrierId, cancellationToken);
     }
@@ -199,8 +200,8 @@ public partial class ShipEngine
     /// <param name="carrierName">The carrier name, such as &#x60;stamps_com&#x60;, &#x60;ups&#x60;, &#x60;fedex&#x60;, or &#x60;dhl_express&#x60;.</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> DisconnectCarrier(HttpClient methodClient, CarrierName carrierName, string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> DisconnectCarrier(HttpClient methodClient, CarrierName carrierName, string carrierId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'carrierName' is set
         if (carrierName == null)
@@ -222,9 +223,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarrierAccountsApi.DisconnectCarrier";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Delete, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -235,8 +237,8 @@ public partial class ShipEngine
     /// <param name="carrierName">The carrier name, such as &#x60;ups&#x60;, &#x60;fedex&#x60;, or &#x60;dhl_express&#x60;.</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarrierSettingsResponseBody)</returns>
-    public Task<GetCarrierSettingsResponseBody> GetCarrierSettings(CarrierNameWithSettings carrierName, string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetCarrierSettingsResponseBody)</returns>
+    public Task<ShipEngineResponse<GetCarrierSettingsResponseBody>> GetCarrierSettings(CarrierNameWithSettings carrierName, string carrierId, CancellationToken cancellationToken = default)
     {
         return GetCarrierSettings(_client, carrierName, carrierId, cancellationToken);
     }
@@ -250,8 +252,8 @@ public partial class ShipEngine
     /// <param name="carrierName">The carrier name, such as &#x60;ups&#x60;, &#x60;fedex&#x60;, or &#x60;dhl_express&#x60;.</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarrierSettingsResponseBody)</returns>
-    public async Task<GetCarrierSettingsResponseBody> GetCarrierSettings(HttpClient methodClient, CarrierNameWithSettings carrierName, string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetCarrierSettingsResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetCarrierSettingsResponseBody>> GetCarrierSettings(HttpClient methodClient, CarrierNameWithSettings carrierName, string carrierId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'carrierName' is set
         if (carrierName == null)
@@ -273,9 +275,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarrierAccountsApi.GetCarrierSettings";
 
-        var result = await SendHttpRequestAsync<GetCarrierSettingsResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetCarrierSettingsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetCarrierSettingsResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -287,8 +290,8 @@ public partial class ShipEngine
     /// <param name="updateCarrierSettingsRequestBody"></param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> UpdateCarrierSettings(CarrierNameWithSettings carrierName, UpdateCarrierSettingsRequestBody updateCarrierSettingsRequestBody, string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> UpdateCarrierSettings(CarrierNameWithSettings carrierName, UpdateCarrierSettingsRequestBody updateCarrierSettingsRequestBody, string carrierId, CancellationToken cancellationToken = default)
     {
         return UpdateCarrierSettings(_client, carrierName, updateCarrierSettingsRequestBody, carrierId, cancellationToken);
     }
@@ -303,8 +306,8 @@ public partial class ShipEngine
     /// <param name="updateCarrierSettingsRequestBody"></param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> UpdateCarrierSettings(HttpClient methodClient, CarrierNameWithSettings carrierName, UpdateCarrierSettingsRequestBody updateCarrierSettingsRequestBody, string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> UpdateCarrierSettings(HttpClient methodClient, CarrierNameWithSettings carrierName, UpdateCarrierSettingsRequestBody updateCarrierSettingsRequestBody, string carrierId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'carrierName' is set
         if (carrierName == null)
@@ -333,9 +336,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarrierAccountsApi.UpdateCarrierSettings";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/CarriersApi.cs
+++ b/ShipEngineSDK/Api/CarriersApi.cs
@@ -32,8 +32,8 @@ public partial interface IShipEngine
     /// <param name="addFundsToCarrierRequestBody"></param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (AddFundsToCarrierResponseBody)</returns>
-    Task<AddFundsToCarrierResponseBody> AddFundsToCarrier(AddFundsToCarrierRequestBody addFundsToCarrierRequestBody, string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (AddFundsToCarrierResponseBody)</returns>
+    Task<ShipEngineResponse<AddFundsToCarrierResponseBody>> AddFundsToCarrier(AddFundsToCarrierRequestBody addFundsToCarrierRequestBody, string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Add Funds To Carrier Add Funds To A Carrier
@@ -44,8 +44,8 @@ public partial interface IShipEngine
     /// <param name="addFundsToCarrierRequestBody"></param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (AddFundsToCarrierResponseBody)</returns>
-    Task<AddFundsToCarrierResponseBody> AddFundsToCarrier(HttpClient methodClient, AddFundsToCarrierRequestBody addFundsToCarrierRequestBody, string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (AddFundsToCarrierResponseBody)</returns>
+    Task<ShipEngineResponse<AddFundsToCarrierResponseBody>> AddFundsToCarrier(HttpClient methodClient, AddFundsToCarrierRequestBody addFundsToCarrierRequestBody, string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Disconnect Carrier by ID Disconnect a Carrier of the given ID from the account
@@ -54,8 +54,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DisconnectCarrierById(string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DisconnectCarrierById(string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Disconnect Carrier by ID Disconnect a Carrier of the given ID from the account
@@ -65,8 +65,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DisconnectCarrierById(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DisconnectCarrierById(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Carrier By ID Retrive carrier info by ID
@@ -75,8 +75,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarrierByIdResponseBody)</returns>
-    Task<GetCarrierByIdResponseBody> GetCarrierById(string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetCarrierByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetCarrierByIdResponseBody>> GetCarrierById(string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Carrier By ID Retrive carrier info by ID
@@ -86,8 +86,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarrierByIdResponseBody)</returns>
-    Task<GetCarrierByIdResponseBody> GetCarrierById(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetCarrierByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetCarrierByIdResponseBody>> GetCarrierById(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Carrier Options Get a list of the options available for the carrier
@@ -96,8 +96,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarrierOptionsResponseBody)</returns>
-    Task<GetCarrierOptionsResponseBody> GetCarrierOptions(string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetCarrierOptionsResponseBody)</returns>
+    Task<ShipEngineResponse<GetCarrierOptionsResponseBody>> GetCarrierOptions(string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Carrier Options Get a list of the options available for the carrier
@@ -107,8 +107,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarrierOptionsResponseBody)</returns>
-    Task<GetCarrierOptionsResponseBody> GetCarrierOptions(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetCarrierOptionsResponseBody)</returns>
+    Task<ShipEngineResponse<GetCarrierOptionsResponseBody>> GetCarrierOptions(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Carrier Package Types List the package types associated with the carrier
@@ -117,8 +117,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListCarrierPackageTypesResponseBody)</returns>
-    Task<ListCarrierPackageTypesResponseBody> ListCarrierPackageTypes(string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListCarrierPackageTypesResponseBody)</returns>
+    Task<ShipEngineResponse<ListCarrierPackageTypesResponseBody>> ListCarrierPackageTypes(string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Carrier Package Types List the package types associated with the carrier
@@ -128,8 +128,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListCarrierPackageTypesResponseBody)</returns>
-    Task<ListCarrierPackageTypesResponseBody> ListCarrierPackageTypes(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListCarrierPackageTypesResponseBody)</returns>
+    Task<ShipEngineResponse<ListCarrierPackageTypesResponseBody>> ListCarrierPackageTypes(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Carrier Services List the services associated with the carrier ID
@@ -138,8 +138,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListCarrierServicesResponseBody)</returns>
-    Task<ListCarrierServicesResponseBody> ListCarrierServices(string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListCarrierServicesResponseBody)</returns>
+    Task<ShipEngineResponse<ListCarrierServicesResponseBody>> ListCarrierServices(string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Carrier Services List the services associated with the carrier ID
@@ -149,8 +149,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListCarrierServicesResponseBody)</returns>
-    Task<ListCarrierServicesResponseBody> ListCarrierServices(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListCarrierServicesResponseBody)</returns>
+    Task<ShipEngineResponse<ListCarrierServicesResponseBody>> ListCarrierServices(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Carriers List all carriers that have been added to this account
@@ -158,8 +158,8 @@ public partial interface IShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarriersResponseBody)</returns>
-    Task<GetCarriersResponseBody> ListCarriers(CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetCarriersResponseBody)</returns>
+    Task<ShipEngineResponse<GetCarriersResponseBody>> ListCarriers(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Carriers List all carriers that have been added to this account
@@ -168,8 +168,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarriersResponseBody)</returns>
-    Task<GetCarriersResponseBody> ListCarriers(HttpClient methodClient, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetCarriersResponseBody)</returns>
+    Task<ShipEngineResponse<GetCarriersResponseBody>> ListCarriers(HttpClient methodClient, CancellationToken cancellationToken = default);
 
 }
 
@@ -186,8 +186,8 @@ public partial class ShipEngine
     /// <param name="addFundsToCarrierRequestBody"></param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (AddFundsToCarrierResponseBody)</returns>
-    public Task<AddFundsToCarrierResponseBody> AddFundsToCarrier(AddFundsToCarrierRequestBody addFundsToCarrierRequestBody, string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (AddFundsToCarrierResponseBody)</returns>
+    public Task<ShipEngineResponse<AddFundsToCarrierResponseBody>> AddFundsToCarrier(AddFundsToCarrierRequestBody addFundsToCarrierRequestBody, string carrierId, CancellationToken cancellationToken = default)
     {
         return AddFundsToCarrier(_client, addFundsToCarrierRequestBody, carrierId, cancellationToken);
     }
@@ -201,8 +201,8 @@ public partial class ShipEngine
     /// <param name="addFundsToCarrierRequestBody"></param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (AddFundsToCarrierResponseBody)</returns>
-    public async Task<AddFundsToCarrierResponseBody> AddFundsToCarrier(HttpClient methodClient, AddFundsToCarrierRequestBody addFundsToCarrierRequestBody, string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (AddFundsToCarrierResponseBody)</returns>
+    public async Task<ShipEngineResponse<AddFundsToCarrierResponseBody>> AddFundsToCarrier(HttpClient methodClient, AddFundsToCarrierRequestBody addFundsToCarrierRequestBody, string carrierId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'addFundsToCarrierRequestBody' is set
         if (addFundsToCarrierRequestBody == null)
@@ -224,9 +224,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.AddFundsToCarrier";
 
-        var result = await SendHttpRequestAsync<AddFundsToCarrierResponseBody>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<AddFundsToCarrierResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<AddFundsToCarrierResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -236,8 +237,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> DisconnectCarrierById(string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> DisconnectCarrierById(string carrierId, CancellationToken cancellationToken = default)
     {
         return DisconnectCarrierById(_client, carrierId, cancellationToken);
     }
@@ -250,8 +251,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> DisconnectCarrierById(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> DisconnectCarrierById(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'carrierId' is set
         if (carrierId == null)
@@ -266,9 +267,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.DisconnectCarrierById";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Delete, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -278,8 +280,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarrierByIdResponseBody)</returns>
-    public Task<GetCarrierByIdResponseBody> GetCarrierById(string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetCarrierByIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetCarrierByIdResponseBody>> GetCarrierById(string carrierId, CancellationToken cancellationToken = default)
     {
         return GetCarrierById(_client, carrierId, cancellationToken);
     }
@@ -292,8 +294,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarrierByIdResponseBody)</returns>
-    public async Task<GetCarrierByIdResponseBody> GetCarrierById(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetCarrierByIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetCarrierByIdResponseBody>> GetCarrierById(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'carrierId' is set
         if (carrierId == null)
@@ -308,9 +310,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.GetCarrierById";
 
-        var result = await SendHttpRequestAsync<GetCarrierByIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetCarrierByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetCarrierByIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -320,8 +323,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarrierOptionsResponseBody)</returns>
-    public Task<GetCarrierOptionsResponseBody> GetCarrierOptions(string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetCarrierOptionsResponseBody)</returns>
+    public Task<ShipEngineResponse<GetCarrierOptionsResponseBody>> GetCarrierOptions(string carrierId, CancellationToken cancellationToken = default)
     {
         return GetCarrierOptions(_client, carrierId, cancellationToken);
     }
@@ -334,8 +337,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarrierOptionsResponseBody)</returns>
-    public async Task<GetCarrierOptionsResponseBody> GetCarrierOptions(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetCarrierOptionsResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetCarrierOptionsResponseBody>> GetCarrierOptions(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'carrierId' is set
         if (carrierId == null)
@@ -350,9 +353,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.GetCarrierOptions";
 
-        var result = await SendHttpRequestAsync<GetCarrierOptionsResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetCarrierOptionsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetCarrierOptionsResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -362,8 +366,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListCarrierPackageTypesResponseBody)</returns>
-    public Task<ListCarrierPackageTypesResponseBody> ListCarrierPackageTypes(string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListCarrierPackageTypesResponseBody)</returns>
+    public Task<ShipEngineResponse<ListCarrierPackageTypesResponseBody>> ListCarrierPackageTypes(string carrierId, CancellationToken cancellationToken = default)
     {
         return ListCarrierPackageTypes(_client, carrierId, cancellationToken);
     }
@@ -376,8 +380,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListCarrierPackageTypesResponseBody)</returns>
-    public async Task<ListCarrierPackageTypesResponseBody> ListCarrierPackageTypes(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListCarrierPackageTypesResponseBody)</returns>
+    public async Task<ShipEngineResponse<ListCarrierPackageTypesResponseBody>> ListCarrierPackageTypes(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'carrierId' is set
         if (carrierId == null)
@@ -392,9 +396,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.ListCarrierPackageTypes";
 
-        var result = await SendHttpRequestAsync<ListCarrierPackageTypesResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ListCarrierPackageTypesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ListCarrierPackageTypesResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -404,8 +409,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListCarrierServicesResponseBody)</returns>
-    public Task<ListCarrierServicesResponseBody> ListCarrierServices(string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListCarrierServicesResponseBody)</returns>
+    public Task<ShipEngineResponse<ListCarrierServicesResponseBody>> ListCarrierServices(string carrierId, CancellationToken cancellationToken = default)
     {
         return ListCarrierServices(_client, carrierId, cancellationToken);
     }
@@ -418,8 +423,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="carrierId">Carrier ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListCarrierServicesResponseBody)</returns>
-    public async Task<ListCarrierServicesResponseBody> ListCarrierServices(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListCarrierServicesResponseBody)</returns>
+    public async Task<ShipEngineResponse<ListCarrierServicesResponseBody>> ListCarrierServices(HttpClient methodClient, string carrierId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'carrierId' is set
         if (carrierId == null)
@@ -434,9 +439,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.ListCarrierServices";
 
-        var result = await SendHttpRequestAsync<ListCarrierServicesResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ListCarrierServicesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ListCarrierServicesResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -445,8 +451,8 @@ public partial class ShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarriersResponseBody)</returns>
-    public Task<GetCarriersResponseBody> ListCarriers(CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetCarriersResponseBody)</returns>
+    public Task<ShipEngineResponse<GetCarriersResponseBody>> ListCarriers(CancellationToken cancellationToken = default)
     {
         return ListCarriers(_client, cancellationToken);
     }
@@ -458,8 +464,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetCarriersResponseBody)</returns>
-    public async Task<GetCarriersResponseBody> ListCarriers(HttpClient methodClient, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetCarriersResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetCarriersResponseBody>> ListCarriers(HttpClient methodClient, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/carriers");
@@ -467,9 +473,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.ListCarriers";
 
-        var result = await SendHttpRequestAsync<GetCarriersResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetCarriersResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetCarriersResponseBody>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/CarriersApi.cs
+++ b/ShipEngineSDK/Api/CarriersApi.cs
@@ -224,10 +224,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.AddFundsToCarrier";
 
-        var (data, response) = await GetHttpResponse<AddFundsToCarrierResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<AddFundsToCarrierResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<AddFundsToCarrierResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -267,10 +264,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.DisconnectCarrierById";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -310,10 +304,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.GetCarrierById";
 
-        var (data, response) = await GetHttpResponse<GetCarrierByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetCarrierByIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetCarrierByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -353,10 +344,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.GetCarrierOptions";
 
-        var (data, response) = await GetHttpResponse<GetCarrierOptionsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetCarrierOptionsResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetCarrierOptionsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -396,10 +384,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.ListCarrierPackageTypes";
 
-        var (data, response) = await GetHttpResponse<ListCarrierPackageTypesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ListCarrierPackageTypesResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ListCarrierPackageTypesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -439,10 +424,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.ListCarrierServices";
 
-        var (data, response) = await GetHttpResponse<ListCarrierServicesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ListCarrierServicesResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ListCarrierServicesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -473,10 +455,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "CarriersApi.ListCarriers";
 
-        var (data, response) = await GetHttpResponse<GetCarriersResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetCarriersResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetCarriersResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/DownloadsApi.cs
+++ b/ShipEngineSDK/Api/DownloadsApi.cs
@@ -127,10 +127,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "DownloadsApi.DownloadFile";
 
-        var (data, response) = await GetHttpResponse<System.IO.Stream>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<System.IO.Stream>(data, response.StatusCode, headers);
+        return await GetHttpResponse<System.IO.Stream>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/DownloadsApi.cs
+++ b/ShipEngineSDK/Api/DownloadsApi.cs
@@ -35,8 +35,8 @@ public partial interface IShipEngine
     /// <param name="rotation"> (optional)</param>
     /// <param name="download"> (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-    Task<System.IO.Stream> DownloadFile(string subdir, string filename, string dir, int? rotation, string? download, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (System.IO.Stream)</returns>
+    Task<ShipEngineResponse<System.IO.Stream>> DownloadFile(string subdir, string filename, string dir, int? rotation, string? download, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Download File Get File
@@ -50,8 +50,8 @@ public partial interface IShipEngine
     /// <param name="rotation"> (optional)</param>
     /// <param name="download"> (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-    Task<System.IO.Stream> DownloadFile(HttpClient methodClient, string subdir, string filename, string dir, int? rotation, string? download, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (System.IO.Stream)</returns>
+    Task<ShipEngineResponse<System.IO.Stream>> DownloadFile(HttpClient methodClient, string subdir, string filename, string dir, int? rotation, string? download, CancellationToken cancellationToken = default);
 
 }
 
@@ -71,8 +71,8 @@ public partial class ShipEngine
     /// <param name="rotation"> (optional)</param>
     /// <param name="download"> (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-    public Task<System.IO.Stream> DownloadFile(string subdir, string filename, string dir, int? rotation = default, string? download = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (System.IO.Stream)</returns>
+    public Task<ShipEngineResponse<System.IO.Stream>> DownloadFile(string subdir, string filename, string dir, int? rotation = default, string? download = default, CancellationToken cancellationToken = default)
     {
         return DownloadFile(_client, subdir, filename, dir, rotation, download, cancellationToken);
     }
@@ -89,8 +89,8 @@ public partial class ShipEngine
     /// <param name="rotation"> (optional)</param>
     /// <param name="download"> (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-    public async Task<System.IO.Stream> DownloadFile(HttpClient methodClient, string subdir, string filename, string dir, int? rotation = default, string? download = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (System.IO.Stream)</returns>
+    public async Task<ShipEngineResponse<System.IO.Stream>> DownloadFile(HttpClient methodClient, string subdir, string filename, string dir, int? rotation = default, string? download = default, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'subdir' is set
         if (subdir == null)
@@ -127,9 +127,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "DownloadsApi.DownloadFile";
 
-        var result = await SendHttpRequestAsync<System.IO.Stream>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<System.IO.Stream>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<System.IO.Stream>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/InsuranceApi.cs
+++ b/ShipEngineSDK/Api/InsuranceApi.cs
@@ -148,10 +148,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "InsuranceApi.AddFundsToInsurance";
 
-        var (data, response) = await GetHttpResponse<AddFundsToInsuranceResponseBody>(HttpMethods.Patch, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<AddFundsToInsuranceResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<AddFundsToInsuranceResponseBody>(HttpMethods.Patch, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -191,10 +188,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "InsuranceApi.ConnectInsurer";
 
-        var (data, response) = await GetHttpResponse<Object>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<Object>(data, response.StatusCode, headers);
+        return await GetHttpResponse<Object>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -225,10 +219,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "InsuranceApi.DisconnectInsurer";
 
-        var (data, response) = await GetHttpResponse<Object>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<Object>(data, response.StatusCode, headers);
+        return await GetHttpResponse<Object>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -259,10 +250,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "InsuranceApi.GetInsuranceBalance";
 
-        var (data, response) = await GetHttpResponse<GetInsuranceBalanceResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetInsuranceBalanceResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetInsuranceBalanceResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/InsuranceApi.cs
+++ b/ShipEngineSDK/Api/InsuranceApi.cs
@@ -31,8 +31,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="addFundsToInsuranceRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (AddFundsToInsuranceResponseBody)</returns>
-    Task<AddFundsToInsuranceResponseBody> AddFundsToInsurance(AddFundsToInsuranceRequestBody addFundsToInsuranceRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (AddFundsToInsuranceResponseBody)</returns>
+    Task<ShipEngineResponse<AddFundsToInsuranceResponseBody>> AddFundsToInsurance(AddFundsToInsuranceRequestBody addFundsToInsuranceRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Add Funds To Insurance You may need to auto fund your account from time to time. For example, if you don&#39;t normally ship items over $100, and may want to add funds to insurance rather than keeping the account funded. 
@@ -42,8 +42,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="addFundsToInsuranceRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (AddFundsToInsuranceResponseBody)</returns>
-    Task<AddFundsToInsuranceResponseBody> AddFundsToInsurance(HttpClient methodClient, AddFundsToInsuranceRequestBody addFundsToInsuranceRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (AddFundsToInsuranceResponseBody)</returns>
+    Task<ShipEngineResponse<AddFundsToInsuranceResponseBody>> AddFundsToInsurance(HttpClient methodClient, AddFundsToInsuranceRequestBody addFundsToInsuranceRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Connect a Shipsurance Account Connect a Shipsurance Account
@@ -52,8 +52,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="connectInsurerRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (Object)</returns>
-    Task<Object> ConnectInsurer(ConnectInsurerRequestBody connectInsurerRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (Object)</returns>
+    Task<ShipEngineResponse<Object>> ConnectInsurer(ConnectInsurerRequestBody connectInsurerRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Connect a Shipsurance Account Connect a Shipsurance Account
@@ -63,8 +63,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="connectInsurerRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (Object)</returns>
-    Task<Object> ConnectInsurer(HttpClient methodClient, ConnectInsurerRequestBody connectInsurerRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (Object)</returns>
+    Task<ShipEngineResponse<Object>> ConnectInsurer(HttpClient methodClient, ConnectInsurerRequestBody connectInsurerRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Disconnect a Shipsurance Account Disconnect a Shipsurance Account
@@ -72,8 +72,8 @@ public partial interface IShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (Object)</returns>
-    Task<Object> DisconnectInsurer(CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (Object)</returns>
+    Task<ShipEngineResponse<Object>> DisconnectInsurer(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Disconnect a Shipsurance Account Disconnect a Shipsurance Account
@@ -82,8 +82,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (Object)</returns>
-    Task<Object> DisconnectInsurer(HttpClient methodClient, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (Object)</returns>
+    Task<ShipEngineResponse<Object>> DisconnectInsurer(HttpClient methodClient, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Insurance Funds Balance Retrieve the balance of your Shipsurance account.
@@ -91,8 +91,8 @@ public partial interface IShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetInsuranceBalanceResponseBody)</returns>
-    Task<GetInsuranceBalanceResponseBody> GetInsuranceBalance(CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetInsuranceBalanceResponseBody)</returns>
+    Task<ShipEngineResponse<GetInsuranceBalanceResponseBody>> GetInsuranceBalance(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Insurance Funds Balance Retrieve the balance of your Shipsurance account.
@@ -101,8 +101,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetInsuranceBalanceResponseBody)</returns>
-    Task<GetInsuranceBalanceResponseBody> GetInsuranceBalance(HttpClient methodClient, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetInsuranceBalanceResponseBody)</returns>
+    Task<ShipEngineResponse<GetInsuranceBalanceResponseBody>> GetInsuranceBalance(HttpClient methodClient, CancellationToken cancellationToken = default);
 
 }
 
@@ -118,8 +118,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="addFundsToInsuranceRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (AddFundsToInsuranceResponseBody)</returns>
-    public Task<AddFundsToInsuranceResponseBody> AddFundsToInsurance(AddFundsToInsuranceRequestBody addFundsToInsuranceRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (AddFundsToInsuranceResponseBody)</returns>
+    public Task<ShipEngineResponse<AddFundsToInsuranceResponseBody>> AddFundsToInsurance(AddFundsToInsuranceRequestBody addFundsToInsuranceRequestBody, CancellationToken cancellationToken = default)
     {
         return AddFundsToInsurance(_client, addFundsToInsuranceRequestBody, cancellationToken);
     }
@@ -132,8 +132,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="addFundsToInsuranceRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (AddFundsToInsuranceResponseBody)</returns>
-    public async Task<AddFundsToInsuranceResponseBody> AddFundsToInsurance(HttpClient methodClient, AddFundsToInsuranceRequestBody addFundsToInsuranceRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (AddFundsToInsuranceResponseBody)</returns>
+    public async Task<ShipEngineResponse<AddFundsToInsuranceResponseBody>> AddFundsToInsurance(HttpClient methodClient, AddFundsToInsuranceRequestBody addFundsToInsuranceRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'addFundsToInsuranceRequestBody' is set
         if (addFundsToInsuranceRequestBody == null)
@@ -148,9 +148,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "InsuranceApi.AddFundsToInsurance";
 
-        var result = await SendHttpRequestAsync<AddFundsToInsuranceResponseBody>(HttpMethods.Patch, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<AddFundsToInsuranceResponseBody>(HttpMethods.Patch, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<AddFundsToInsuranceResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -160,8 +161,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="connectInsurerRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (Object)</returns>
-    public Task<Object> ConnectInsurer(ConnectInsurerRequestBody connectInsurerRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (Object)</returns>
+    public Task<ShipEngineResponse<Object>> ConnectInsurer(ConnectInsurerRequestBody connectInsurerRequestBody, CancellationToken cancellationToken = default)
     {
         return ConnectInsurer(_client, connectInsurerRequestBody, cancellationToken);
     }
@@ -174,8 +175,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="connectInsurerRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (Object)</returns>
-    public async Task<Object> ConnectInsurer(HttpClient methodClient, ConnectInsurerRequestBody connectInsurerRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (Object)</returns>
+    public async Task<ShipEngineResponse<Object>> ConnectInsurer(HttpClient methodClient, ConnectInsurerRequestBody connectInsurerRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'connectInsurerRequestBody' is set
         if (connectInsurerRequestBody == null)
@@ -190,9 +191,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "InsuranceApi.ConnectInsurer";
 
-        var result = await SendHttpRequestAsync<Object>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<Object>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<Object>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -201,8 +203,8 @@ public partial class ShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (Object)</returns>
-    public Task<Object> DisconnectInsurer(CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (Object)</returns>
+    public Task<ShipEngineResponse<Object>> DisconnectInsurer(CancellationToken cancellationToken = default)
     {
         return DisconnectInsurer(_client, cancellationToken);
     }
@@ -214,8 +216,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (Object)</returns>
-    public async Task<Object> DisconnectInsurer(HttpClient methodClient, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (Object)</returns>
+    public async Task<ShipEngineResponse<Object>> DisconnectInsurer(HttpClient methodClient, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/connections/insurance/shipsurance");
@@ -223,9 +225,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "InsuranceApi.DisconnectInsurer";
 
-        var result = await SendHttpRequestAsync<Object>(HttpMethods.Delete, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<Object>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<Object>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -234,8 +237,8 @@ public partial class ShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetInsuranceBalanceResponseBody)</returns>
-    public Task<GetInsuranceBalanceResponseBody> GetInsuranceBalance(CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetInsuranceBalanceResponseBody)</returns>
+    public Task<ShipEngineResponse<GetInsuranceBalanceResponseBody>> GetInsuranceBalance(CancellationToken cancellationToken = default)
     {
         return GetInsuranceBalance(_client, cancellationToken);
     }
@@ -247,8 +250,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetInsuranceBalanceResponseBody)</returns>
-    public async Task<GetInsuranceBalanceResponseBody> GetInsuranceBalance(HttpClient methodClient, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetInsuranceBalanceResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetInsuranceBalanceResponseBody>> GetInsuranceBalance(HttpClient methodClient, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/insurance/shipsurance/balance");
@@ -256,9 +259,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "InsuranceApi.GetInsuranceBalance";
 
-        var result = await SendHttpRequestAsync<GetInsuranceBalanceResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetInsuranceBalanceResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetInsuranceBalanceResponseBody>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/LabelsApi.cs
+++ b/ShipEngineSDK/Api/LabelsApi.cs
@@ -293,10 +293,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.CreateLabel";
 
-        var (data, response) = await GetHttpResponse<CreateLabelResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<CreateLabelResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<CreateLabelResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -345,10 +342,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.CreateLabelFromRate";
 
-        var (data, response) = await GetHttpResponse<CreateLabelFromRateResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<CreateLabelFromRateResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<CreateLabelFromRateResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -397,10 +391,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.CreateLabelFromShipment";
 
-        var (data, response) = await GetHttpResponse<CreateLabelFromShipmentResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<CreateLabelFromShipmentResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<CreateLabelFromShipmentResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -449,10 +440,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.CreateReturnLabel";
 
-        var (data, response) = await GetHttpResponse<CreateReturnLabelResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<CreateReturnLabelResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<CreateReturnLabelResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -498,10 +486,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.GetLabelByExternalShipmentId";
 
-        var (data, response) = await GetHttpResponse<GetLabelByExternalShipmentIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetLabelByExternalShipmentIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetLabelByExternalShipmentIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -547,10 +532,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.GetLabelById";
 
-        var (data, response) = await GetHttpResponse<GetLabelByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetLabelByIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetLabelByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -590,10 +572,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.GetTrackingLogFromLabel";
 
-        var (data, response) = await GetHttpResponse<GetTrackingLogFromLabelResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetTrackingLogFromLabelResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetTrackingLogFromLabelResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -708,10 +687,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.ListLabels";
 
-        var (data, response) = await GetHttpResponse<ListLabelsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ListLabelsResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ListLabelsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -751,10 +727,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.VoidLabel";
 
-        var (data, response) = await GetHttpResponse<VoidLabelResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<VoidLabelResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<VoidLabelResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/LabelsApi.cs
+++ b/ShipEngineSDK/Api/LabelsApi.cs
@@ -31,8 +31,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createLabelRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateLabelResponseBody)</returns>
-    Task<CreateLabelResponseBody> CreateLabel(CreateLabelRequestBody createLabelRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateLabelResponseBody)</returns>
+    Task<ShipEngineResponse<CreateLabelResponseBody>> CreateLabel(CreateLabelRequestBody createLabelRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Purchase Label Purchase and print a label for shipment
@@ -42,8 +42,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createLabelRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateLabelResponseBody)</returns>
-    Task<CreateLabelResponseBody> CreateLabel(HttpClient methodClient, CreateLabelRequestBody createLabelRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateLabelResponseBody)</returns>
+    Task<ShipEngineResponse<CreateLabelResponseBody>> CreateLabel(HttpClient methodClient, CreateLabelRequestBody createLabelRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Purchase Label with Rate ID When retrieving rates for shipments using the &#x60;/rates&#x60; endpoint, the returned information contains a &#x60;rate_id&#x60; property that can be used to generate a label without having to refill in the shipment information repeatedly. 
@@ -53,8 +53,8 @@ public partial interface IShipEngine
     /// <param name="createLabelFromRateRequestBody"></param>
     /// <param name="rateId">Rate ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateLabelFromRateResponseBody)</returns>
-    Task<CreateLabelFromRateResponseBody> CreateLabelFromRate(CreateLabelFromRateRequestBody createLabelFromRateRequestBody, string rateId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateLabelFromRateResponseBody)</returns>
+    Task<ShipEngineResponse<CreateLabelFromRateResponseBody>> CreateLabelFromRate(CreateLabelFromRateRequestBody createLabelFromRateRequestBody, string rateId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Purchase Label with Rate ID When retrieving rates for shipments using the &#x60;/rates&#x60; endpoint, the returned information contains a &#x60;rate_id&#x60; property that can be used to generate a label without having to refill in the shipment information repeatedly. 
@@ -65,8 +65,8 @@ public partial interface IShipEngine
     /// <param name="createLabelFromRateRequestBody"></param>
     /// <param name="rateId">Rate ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateLabelFromRateResponseBody)</returns>
-    Task<CreateLabelFromRateResponseBody> CreateLabelFromRate(HttpClient methodClient, CreateLabelFromRateRequestBody createLabelFromRateRequestBody, string rateId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateLabelFromRateResponseBody)</returns>
+    Task<ShipEngineResponse<CreateLabelFromRateResponseBody>> CreateLabelFromRate(HttpClient methodClient, CreateLabelFromRateRequestBody createLabelFromRateRequestBody, string rateId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Purchase Label with Shipment ID Purchase a label using a shipment ID that has already been created with the desired address and package info. 
@@ -76,8 +76,8 @@ public partial interface IShipEngine
     /// <param name="createLabelFromShipmentRequestBody"></param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateLabelFromShipmentResponseBody)</returns>
-    Task<CreateLabelFromShipmentResponseBody> CreateLabelFromShipment(CreateLabelFromShipmentRequestBody createLabelFromShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateLabelFromShipmentResponseBody)</returns>
+    Task<ShipEngineResponse<CreateLabelFromShipmentResponseBody>> CreateLabelFromShipment(CreateLabelFromShipmentRequestBody createLabelFromShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Purchase Label with Shipment ID Purchase a label using a shipment ID that has already been created with the desired address and package info. 
@@ -88,8 +88,8 @@ public partial interface IShipEngine
     /// <param name="createLabelFromShipmentRequestBody"></param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateLabelFromShipmentResponseBody)</returns>
-    Task<CreateLabelFromShipmentResponseBody> CreateLabelFromShipment(HttpClient methodClient, CreateLabelFromShipmentRequestBody createLabelFromShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateLabelFromShipmentResponseBody)</returns>
+    Task<ShipEngineResponse<CreateLabelFromShipmentResponseBody>> CreateLabelFromShipment(HttpClient methodClient, CreateLabelFromShipmentRequestBody createLabelFromShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create a return label Create a return label
@@ -99,8 +99,8 @@ public partial interface IShipEngine
     /// <param name="createReturnLabelRequestBody"></param>
     /// <param name="labelId">Label ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateReturnLabelResponseBody)</returns>
-    Task<CreateReturnLabelResponseBody> CreateReturnLabel(CreateReturnLabelRequestBody createReturnLabelRequestBody, string labelId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateReturnLabelResponseBody)</returns>
+    Task<ShipEngineResponse<CreateReturnLabelResponseBody>> CreateReturnLabel(CreateReturnLabelRequestBody createReturnLabelRequestBody, string labelId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create a return label Create a return label
@@ -111,8 +111,8 @@ public partial interface IShipEngine
     /// <param name="createReturnLabelRequestBody"></param>
     /// <param name="labelId">Label ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateReturnLabelResponseBody)</returns>
-    Task<CreateReturnLabelResponseBody> CreateReturnLabel(HttpClient methodClient, CreateReturnLabelRequestBody createReturnLabelRequestBody, string labelId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateReturnLabelResponseBody)</returns>
+    Task<ShipEngineResponse<CreateReturnLabelResponseBody>> CreateReturnLabel(HttpClient methodClient, CreateReturnLabelRequestBody createReturnLabelRequestBody, string labelId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Label By External Shipment ID Find a label by using the external shipment id that was used during label creation 
@@ -122,8 +122,8 @@ public partial interface IShipEngine
     /// <param name="externalShipmentId"></param>
     /// <param name="labelDownloadType"> (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetLabelByExternalShipmentIdResponseBody)</returns>
-    Task<GetLabelByExternalShipmentIdResponseBody> GetLabelByExternalShipmentId(string externalShipmentId, LabelDownloadType? labelDownloadType, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetLabelByExternalShipmentIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetLabelByExternalShipmentIdResponseBody>> GetLabelByExternalShipmentId(string externalShipmentId, LabelDownloadType? labelDownloadType, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Label By External Shipment ID Find a label by using the external shipment id that was used during label creation 
@@ -134,8 +134,8 @@ public partial interface IShipEngine
     /// <param name="externalShipmentId"></param>
     /// <param name="labelDownloadType"> (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetLabelByExternalShipmentIdResponseBody)</returns>
-    Task<GetLabelByExternalShipmentIdResponseBody> GetLabelByExternalShipmentId(HttpClient methodClient, string externalShipmentId, LabelDownloadType? labelDownloadType, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetLabelByExternalShipmentIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetLabelByExternalShipmentIdResponseBody>> GetLabelByExternalShipmentId(HttpClient methodClient, string externalShipmentId, LabelDownloadType? labelDownloadType, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Label By ID Retrieve information for individual labels.
@@ -145,8 +145,8 @@ public partial interface IShipEngine
     /// <param name="labelId">Label ID</param>
     /// <param name="labelDownloadType"> (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetLabelByIdResponseBody)</returns>
-    Task<GetLabelByIdResponseBody> GetLabelById(string labelId, LabelDownloadType? labelDownloadType, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetLabelByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetLabelByIdResponseBody>> GetLabelById(string labelId, LabelDownloadType? labelDownloadType, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Label By ID Retrieve information for individual labels.
@@ -157,8 +157,8 @@ public partial interface IShipEngine
     /// <param name="labelId">Label ID</param>
     /// <param name="labelDownloadType"> (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetLabelByIdResponseBody)</returns>
-    Task<GetLabelByIdResponseBody> GetLabelById(HttpClient methodClient, string labelId, LabelDownloadType? labelDownloadType, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetLabelByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetLabelByIdResponseBody>> GetLabelById(HttpClient methodClient, string labelId, LabelDownloadType? labelDownloadType, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Label Tracking Information Retrieve the label&#39;s tracking information
@@ -167,8 +167,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="labelId">Label ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetTrackingLogFromLabelResponseBody)</returns>
-    Task<GetTrackingLogFromLabelResponseBody> GetTrackingLogFromLabel(string labelId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetTrackingLogFromLabelResponseBody)</returns>
+    Task<ShipEngineResponse<GetTrackingLogFromLabelResponseBody>> GetTrackingLogFromLabel(string labelId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Label Tracking Information Retrieve the label&#39;s tracking information
@@ -178,8 +178,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="labelId">Label ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetTrackingLogFromLabelResponseBody)</returns>
-    Task<GetTrackingLogFromLabelResponseBody> GetTrackingLogFromLabel(HttpClient methodClient, string labelId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetTrackingLogFromLabelResponseBody)</returns>
+    Task<ShipEngineResponse<GetTrackingLogFromLabelResponseBody>> GetTrackingLogFromLabel(HttpClient methodClient, string labelId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List labels This endpoint returns a list of labels that you&#39;ve [created](https://www.shipengine.com/docs/labels/create-a-label/). You can optionally filter the results as well as control their sort order and the number of results returned at a time.  By default, all labels are returned, 25 at a time, starting with the most recently created ones.  You can combine multiple filter options to narrow-down the results.  For example, if you only want to get your UPS labels for your east coast warehouse you could query by both &#x60;warehouse_id&#x60; and &#x60;carrier_id&#x60; 
@@ -201,8 +201,8 @@ public partial interface IShipEngine
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="sortBy">Controls which field the query is sorted by. (optional, default to created_at)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListLabelsResponseBody)</returns>
-    Task<ListLabelsResponseBody> ListLabels(DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, LabelStatus? labelStatus, SortDir? sortDir, string? serviceCode, string? carrierId, string? trackingNumber, string? batchId, string? rateId, string? shipmentId, string? warehouseId, int? page, int? pageSize, string? sortBy, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListLabelsResponseBody)</returns>
+    Task<ShipEngineResponse<ListLabelsResponseBody>> ListLabels(DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, LabelStatus? labelStatus, SortDir? sortDir, string? serviceCode, string? carrierId, string? trackingNumber, string? batchId, string? rateId, string? shipmentId, string? warehouseId, int? page, int? pageSize, string? sortBy, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List labels This endpoint returns a list of labels that you&#39;ve [created](https://www.shipengine.com/docs/labels/create-a-label/). You can optionally filter the results as well as control their sort order and the number of results returned at a time.  By default, all labels are returned, 25 at a time, starting with the most recently created ones.  You can combine multiple filter options to narrow-down the results.  For example, if you only want to get your UPS labels for your east coast warehouse you could query by both &#x60;warehouse_id&#x60; and &#x60;carrier_id&#x60; 
@@ -225,8 +225,8 @@ public partial interface IShipEngine
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="sortBy">Controls which field the query is sorted by. (optional, default to created_at)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListLabelsResponseBody)</returns>
-    Task<ListLabelsResponseBody> ListLabels(HttpClient methodClient, DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, LabelStatus? labelStatus, SortDir? sortDir, string? serviceCode, string? carrierId, string? trackingNumber, string? batchId, string? rateId, string? shipmentId, string? warehouseId, int? page, int? pageSize, string? sortBy, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListLabelsResponseBody)</returns>
+    Task<ShipEngineResponse<ListLabelsResponseBody>> ListLabels(HttpClient methodClient, DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, LabelStatus? labelStatus, SortDir? sortDir, string? serviceCode, string? carrierId, string? trackingNumber, string? batchId, string? rateId, string? shipmentId, string? warehouseId, int? page, int? pageSize, string? sortBy, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Void a Label By ID Void a label by ID to get a refund.
@@ -235,8 +235,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="labelId">Label ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (VoidLabelResponseBody)</returns>
-    Task<VoidLabelResponseBody> VoidLabel(string labelId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (VoidLabelResponseBody)</returns>
+    Task<ShipEngineResponse<VoidLabelResponseBody>> VoidLabel(string labelId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Void a Label By ID Void a label by ID to get a refund.
@@ -246,8 +246,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="labelId">Label ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (VoidLabelResponseBody)</returns>
-    Task<VoidLabelResponseBody> VoidLabel(HttpClient methodClient, string labelId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (VoidLabelResponseBody)</returns>
+    Task<ShipEngineResponse<VoidLabelResponseBody>> VoidLabel(HttpClient methodClient, string labelId, CancellationToken cancellationToken = default);
 
 }
 
@@ -263,8 +263,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createLabelRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateLabelResponseBody)</returns>
-    public Task<CreateLabelResponseBody> CreateLabel(CreateLabelRequestBody createLabelRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateLabelResponseBody)</returns>
+    public Task<ShipEngineResponse<CreateLabelResponseBody>> CreateLabel(CreateLabelRequestBody createLabelRequestBody, CancellationToken cancellationToken = default)
     {
         return CreateLabel(_client, createLabelRequestBody, cancellationToken);
     }
@@ -277,8 +277,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createLabelRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateLabelResponseBody)</returns>
-    public async Task<CreateLabelResponseBody> CreateLabel(HttpClient methodClient, CreateLabelRequestBody createLabelRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateLabelResponseBody)</returns>
+    public async Task<ShipEngineResponse<CreateLabelResponseBody>> CreateLabel(HttpClient methodClient, CreateLabelRequestBody createLabelRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'createLabelRequestBody' is set
         if (createLabelRequestBody == null)
@@ -293,9 +293,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.CreateLabel";
 
-        var result = await SendHttpRequestAsync<CreateLabelResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<CreateLabelResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<CreateLabelResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -306,8 +307,8 @@ public partial class ShipEngine
     /// <param name="createLabelFromRateRequestBody"></param>
     /// <param name="rateId">Rate ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateLabelFromRateResponseBody)</returns>
-    public Task<CreateLabelFromRateResponseBody> CreateLabelFromRate(CreateLabelFromRateRequestBody createLabelFromRateRequestBody, string rateId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateLabelFromRateResponseBody)</returns>
+    public Task<ShipEngineResponse<CreateLabelFromRateResponseBody>> CreateLabelFromRate(CreateLabelFromRateRequestBody createLabelFromRateRequestBody, string rateId, CancellationToken cancellationToken = default)
     {
         return CreateLabelFromRate(_client, createLabelFromRateRequestBody, rateId, cancellationToken);
     }
@@ -321,8 +322,8 @@ public partial class ShipEngine
     /// <param name="createLabelFromRateRequestBody"></param>
     /// <param name="rateId">Rate ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateLabelFromRateResponseBody)</returns>
-    public async Task<CreateLabelFromRateResponseBody> CreateLabelFromRate(HttpClient methodClient, CreateLabelFromRateRequestBody createLabelFromRateRequestBody, string rateId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateLabelFromRateResponseBody)</returns>
+    public async Task<ShipEngineResponse<CreateLabelFromRateResponseBody>> CreateLabelFromRate(HttpClient methodClient, CreateLabelFromRateRequestBody createLabelFromRateRequestBody, string rateId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'createLabelFromRateRequestBody' is set
         if (createLabelFromRateRequestBody == null)
@@ -344,9 +345,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.CreateLabelFromRate";
 
-        var result = await SendHttpRequestAsync<CreateLabelFromRateResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<CreateLabelFromRateResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<CreateLabelFromRateResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -357,8 +359,8 @@ public partial class ShipEngine
     /// <param name="createLabelFromShipmentRequestBody"></param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateLabelFromShipmentResponseBody)</returns>
-    public Task<CreateLabelFromShipmentResponseBody> CreateLabelFromShipment(CreateLabelFromShipmentRequestBody createLabelFromShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateLabelFromShipmentResponseBody)</returns>
+    public Task<ShipEngineResponse<CreateLabelFromShipmentResponseBody>> CreateLabelFromShipment(CreateLabelFromShipmentRequestBody createLabelFromShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default)
     {
         return CreateLabelFromShipment(_client, createLabelFromShipmentRequestBody, shipmentId, cancellationToken);
     }
@@ -372,8 +374,8 @@ public partial class ShipEngine
     /// <param name="createLabelFromShipmentRequestBody"></param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateLabelFromShipmentResponseBody)</returns>
-    public async Task<CreateLabelFromShipmentResponseBody> CreateLabelFromShipment(HttpClient methodClient, CreateLabelFromShipmentRequestBody createLabelFromShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateLabelFromShipmentResponseBody)</returns>
+    public async Task<ShipEngineResponse<CreateLabelFromShipmentResponseBody>> CreateLabelFromShipment(HttpClient methodClient, CreateLabelFromShipmentRequestBody createLabelFromShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'createLabelFromShipmentRequestBody' is set
         if (createLabelFromShipmentRequestBody == null)
@@ -395,9 +397,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.CreateLabelFromShipment";
 
-        var result = await SendHttpRequestAsync<CreateLabelFromShipmentResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<CreateLabelFromShipmentResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<CreateLabelFromShipmentResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -408,8 +411,8 @@ public partial class ShipEngine
     /// <param name="createReturnLabelRequestBody"></param>
     /// <param name="labelId">Label ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateReturnLabelResponseBody)</returns>
-    public Task<CreateReturnLabelResponseBody> CreateReturnLabel(CreateReturnLabelRequestBody createReturnLabelRequestBody, string labelId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateReturnLabelResponseBody)</returns>
+    public Task<ShipEngineResponse<CreateReturnLabelResponseBody>> CreateReturnLabel(CreateReturnLabelRequestBody createReturnLabelRequestBody, string labelId, CancellationToken cancellationToken = default)
     {
         return CreateReturnLabel(_client, createReturnLabelRequestBody, labelId, cancellationToken);
     }
@@ -423,8 +426,8 @@ public partial class ShipEngine
     /// <param name="createReturnLabelRequestBody"></param>
     /// <param name="labelId">Label ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateReturnLabelResponseBody)</returns>
-    public async Task<CreateReturnLabelResponseBody> CreateReturnLabel(HttpClient methodClient, CreateReturnLabelRequestBody createReturnLabelRequestBody, string labelId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateReturnLabelResponseBody)</returns>
+    public async Task<ShipEngineResponse<CreateReturnLabelResponseBody>> CreateReturnLabel(HttpClient methodClient, CreateReturnLabelRequestBody createReturnLabelRequestBody, string labelId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'createReturnLabelRequestBody' is set
         if (createReturnLabelRequestBody == null)
@@ -446,9 +449,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.CreateReturnLabel";
 
-        var result = await SendHttpRequestAsync<CreateReturnLabelResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<CreateReturnLabelResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<CreateReturnLabelResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -459,8 +463,8 @@ public partial class ShipEngine
     /// <param name="externalShipmentId"></param>
     /// <param name="labelDownloadType"> (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetLabelByExternalShipmentIdResponseBody)</returns>
-    public Task<GetLabelByExternalShipmentIdResponseBody> GetLabelByExternalShipmentId(string externalShipmentId, LabelDownloadType? labelDownloadType = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetLabelByExternalShipmentIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetLabelByExternalShipmentIdResponseBody>> GetLabelByExternalShipmentId(string externalShipmentId, LabelDownloadType? labelDownloadType = default, CancellationToken cancellationToken = default)
     {
         return GetLabelByExternalShipmentId(_client, externalShipmentId, labelDownloadType, cancellationToken);
     }
@@ -474,8 +478,8 @@ public partial class ShipEngine
     /// <param name="externalShipmentId"></param>
     /// <param name="labelDownloadType"> (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetLabelByExternalShipmentIdResponseBody)</returns>
-    public async Task<GetLabelByExternalShipmentIdResponseBody> GetLabelByExternalShipmentId(HttpClient methodClient, string externalShipmentId, LabelDownloadType? labelDownloadType = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetLabelByExternalShipmentIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetLabelByExternalShipmentIdResponseBody>> GetLabelByExternalShipmentId(HttpClient methodClient, string externalShipmentId, LabelDownloadType? labelDownloadType = default, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'externalShipmentId' is set
         if (externalShipmentId == null)
@@ -494,9 +498,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.GetLabelByExternalShipmentId";
 
-        var result = await SendHttpRequestAsync<GetLabelByExternalShipmentIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetLabelByExternalShipmentIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetLabelByExternalShipmentIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -507,8 +512,8 @@ public partial class ShipEngine
     /// <param name="labelId">Label ID</param>
     /// <param name="labelDownloadType"> (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetLabelByIdResponseBody)</returns>
-    public Task<GetLabelByIdResponseBody> GetLabelById(string labelId, LabelDownloadType? labelDownloadType = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetLabelByIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetLabelByIdResponseBody>> GetLabelById(string labelId, LabelDownloadType? labelDownloadType = default, CancellationToken cancellationToken = default)
     {
         return GetLabelById(_client, labelId, labelDownloadType, cancellationToken);
     }
@@ -522,8 +527,8 @@ public partial class ShipEngine
     /// <param name="labelId">Label ID</param>
     /// <param name="labelDownloadType"> (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetLabelByIdResponseBody)</returns>
-    public async Task<GetLabelByIdResponseBody> GetLabelById(HttpClient methodClient, string labelId, LabelDownloadType? labelDownloadType = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetLabelByIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetLabelByIdResponseBody>> GetLabelById(HttpClient methodClient, string labelId, LabelDownloadType? labelDownloadType = default, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'labelId' is set
         if (labelId == null)
@@ -542,9 +547,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.GetLabelById";
 
-        var result = await SendHttpRequestAsync<GetLabelByIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetLabelByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetLabelByIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -554,8 +560,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="labelId">Label ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetTrackingLogFromLabelResponseBody)</returns>
-    public Task<GetTrackingLogFromLabelResponseBody> GetTrackingLogFromLabel(string labelId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetTrackingLogFromLabelResponseBody)</returns>
+    public Task<ShipEngineResponse<GetTrackingLogFromLabelResponseBody>> GetTrackingLogFromLabel(string labelId, CancellationToken cancellationToken = default)
     {
         return GetTrackingLogFromLabel(_client, labelId, cancellationToken);
     }
@@ -568,8 +574,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="labelId">Label ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetTrackingLogFromLabelResponseBody)</returns>
-    public async Task<GetTrackingLogFromLabelResponseBody> GetTrackingLogFromLabel(HttpClient methodClient, string labelId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetTrackingLogFromLabelResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetTrackingLogFromLabelResponseBody>> GetTrackingLogFromLabel(HttpClient methodClient, string labelId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'labelId' is set
         if (labelId == null)
@@ -584,9 +590,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.GetTrackingLogFromLabel";
 
-        var result = await SendHttpRequestAsync<GetTrackingLogFromLabelResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetTrackingLogFromLabelResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetTrackingLogFromLabelResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -609,8 +616,8 @@ public partial class ShipEngine
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="sortBy">Controls which field the query is sorted by. (optional, default to created_at)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListLabelsResponseBody)</returns>
-    public Task<ListLabelsResponseBody> ListLabels(DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, LabelStatus? labelStatus = default, SortDir? sortDir = default, string? serviceCode = default, string? carrierId = default, string? trackingNumber = default, string? batchId = default, string? rateId = default, string? shipmentId = default, string? warehouseId = default, int? page = default, int? pageSize = default, string? sortBy = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListLabelsResponseBody)</returns>
+    public Task<ShipEngineResponse<ListLabelsResponseBody>> ListLabels(DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, LabelStatus? labelStatus = default, SortDir? sortDir = default, string? serviceCode = default, string? carrierId = default, string? trackingNumber = default, string? batchId = default, string? rateId = default, string? shipmentId = default, string? warehouseId = default, int? page = default, int? pageSize = default, string? sortBy = default, CancellationToken cancellationToken = default)
     {
         return ListLabels(_client, createdAtStart, createdAtEnd, labelStatus, sortDir, serviceCode, carrierId, trackingNumber, batchId, rateId, shipmentId, warehouseId, page, pageSize, sortBy, cancellationToken);
     }
@@ -636,8 +643,8 @@ public partial class ShipEngine
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="sortBy">Controls which field the query is sorted by. (optional, default to created_at)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListLabelsResponseBody)</returns>
-    public async Task<ListLabelsResponseBody> ListLabels(HttpClient methodClient, DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, LabelStatus? labelStatus = default, SortDir? sortDir = default, string? serviceCode = default, string? carrierId = default, string? trackingNumber = default, string? batchId = default, string? rateId = default, string? shipmentId = default, string? warehouseId = default, int? page = default, int? pageSize = default, string? sortBy = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListLabelsResponseBody)</returns>
+    public async Task<ShipEngineResponse<ListLabelsResponseBody>> ListLabels(HttpClient methodClient, DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, LabelStatus? labelStatus = default, SortDir? sortDir = default, string? serviceCode = default, string? carrierId = default, string? trackingNumber = default, string? batchId = default, string? rateId = default, string? shipmentId = default, string? warehouseId = default, int? page = default, int? pageSize = default, string? sortBy = default, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/labels");
@@ -701,9 +708,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.ListLabels";
 
-        var result = await SendHttpRequestAsync<ListLabelsResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ListLabelsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ListLabelsResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -713,8 +721,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="labelId">Label ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (VoidLabelResponseBody)</returns>
-    public Task<VoidLabelResponseBody> VoidLabel(string labelId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (VoidLabelResponseBody)</returns>
+    public Task<ShipEngineResponse<VoidLabelResponseBody>> VoidLabel(string labelId, CancellationToken cancellationToken = default)
     {
         return VoidLabel(_client, labelId, cancellationToken);
     }
@@ -727,8 +735,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="labelId">Label ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (VoidLabelResponseBody)</returns>
-    public async Task<VoidLabelResponseBody> VoidLabel(HttpClient methodClient, string labelId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (VoidLabelResponseBody)</returns>
+    public async Task<ShipEngineResponse<VoidLabelResponseBody>> VoidLabel(HttpClient methodClient, string labelId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'labelId' is set
         if (labelId == null)
@@ -743,9 +751,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "LabelsApi.VoidLabel";
 
-        var result = await SendHttpRequestAsync<VoidLabelResponseBody>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<VoidLabelResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<VoidLabelResponseBody>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/ManifestsApi.cs
+++ b/ShipEngineSDK/Api/ManifestsApi.cs
@@ -31,8 +31,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createManifestRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateManifestResponseBody)</returns>
-    Task<CreateManifestResponseBody> CreateManifest(CreateManifestRequestBody createManifestRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateManifestResponseBody)</returns>
+    Task<ShipEngineResponse<CreateManifestResponseBody>> CreateManifest(CreateManifestRequestBody createManifestRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create Manifest Each ShipEngine manifest is created for a specific warehouse, so you&#39;ll need to provide the warehouse_id rather than the ship_from address. You can create a warehouse for each location that you want to create manifests for. 
@@ -42,8 +42,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createManifestRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateManifestResponseBody)</returns>
-    Task<CreateManifestResponseBody> CreateManifest(HttpClient methodClient, CreateManifestRequestBody createManifestRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateManifestResponseBody)</returns>
+    Task<ShipEngineResponse<CreateManifestResponseBody>> CreateManifest(HttpClient methodClient, CreateManifestRequestBody createManifestRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Manifest By Id Get Manifest By Id
@@ -52,8 +52,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="manifestId">The Manifest Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetManifestByIdResponseBody)</returns>
-    Task<GetManifestByIdResponseBody> GetManifestById(string manifestId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetManifestByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetManifestByIdResponseBody>> GetManifestById(string manifestId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Manifest By Id Get Manifest By Id
@@ -63,8 +63,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="manifestId">The Manifest Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetManifestByIdResponseBody)</returns>
-    Task<GetManifestByIdResponseBody> GetManifestById(HttpClient methodClient, string manifestId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetManifestByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetManifestByIdResponseBody>> GetManifestById(HttpClient methodClient, string manifestId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Manifest Request By Id Get Manifest Request By Id
@@ -73,8 +73,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="manifestRequestId">The Manifest Request Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateManifestResponseBody)</returns>
-    Task<CreateManifestResponseBody> GetManifestRequestById(string manifestRequestId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateManifestResponseBody)</returns>
+    Task<ShipEngineResponse<CreateManifestResponseBody>> GetManifestRequestById(string manifestRequestId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Manifest Request By Id Get Manifest Request By Id
@@ -84,8 +84,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="manifestRequestId">The Manifest Request Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateManifestResponseBody)</returns>
-    Task<CreateManifestResponseBody> GetManifestRequestById(HttpClient methodClient, string manifestRequestId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateManifestResponseBody)</returns>
+    Task<ShipEngineResponse<CreateManifestResponseBody>> GetManifestRequestById(HttpClient methodClient, string manifestRequestId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Manifests Similar to querying shipments, we allow you to query manifests since there will likely be a large number over a long period of time.
@@ -102,8 +102,8 @@ public partial interface IShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListManifestsResponseBody)</returns>
-    Task<ListManifestsResponseBody> ListManifests(DateTimeOffset? shipDateStart, DateTimeOffset? shipDateEnd, DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, List<string>? labelIds, string? warehouseId, string? carrierId, int? page, int? pageSize, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListManifestsResponseBody)</returns>
+    Task<ShipEngineResponse<ListManifestsResponseBody>> ListManifests(DateTimeOffset? shipDateStart, DateTimeOffset? shipDateEnd, DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, List<string>? labelIds, string? warehouseId, string? carrierId, int? page, int? pageSize, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Manifests Similar to querying shipments, we allow you to query manifests since there will likely be a large number over a long period of time.
@@ -121,8 +121,8 @@ public partial interface IShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListManifestsResponseBody)</returns>
-    Task<ListManifestsResponseBody> ListManifests(HttpClient methodClient, DateTimeOffset? shipDateStart, DateTimeOffset? shipDateEnd, DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, List<string>? labelIds, string? warehouseId, string? carrierId, int? page, int? pageSize, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListManifestsResponseBody)</returns>
+    Task<ShipEngineResponse<ListManifestsResponseBody>> ListManifests(HttpClient methodClient, DateTimeOffset? shipDateStart, DateTimeOffset? shipDateEnd, DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, List<string>? labelIds, string? warehouseId, string? carrierId, int? page, int? pageSize, CancellationToken cancellationToken = default);
 
 }
 
@@ -138,8 +138,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createManifestRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateManifestResponseBody)</returns>
-    public Task<CreateManifestResponseBody> CreateManifest(CreateManifestRequestBody createManifestRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateManifestResponseBody)</returns>
+    public Task<ShipEngineResponse<CreateManifestResponseBody>> CreateManifest(CreateManifestRequestBody createManifestRequestBody, CancellationToken cancellationToken = default)
     {
         return CreateManifest(_client, createManifestRequestBody, cancellationToken);
     }
@@ -152,8 +152,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createManifestRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateManifestResponseBody)</returns>
-    public async Task<CreateManifestResponseBody> CreateManifest(HttpClient methodClient, CreateManifestRequestBody createManifestRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateManifestResponseBody)</returns>
+    public async Task<ShipEngineResponse<CreateManifestResponseBody>> CreateManifest(HttpClient methodClient, CreateManifestRequestBody createManifestRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'createManifestRequestBody' is set
         if (createManifestRequestBody == null)
@@ -168,9 +168,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ManifestsApi.CreateManifest";
 
-        var result = await SendHttpRequestAsync<CreateManifestResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<CreateManifestResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<CreateManifestResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -180,8 +181,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="manifestId">The Manifest Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetManifestByIdResponseBody)</returns>
-    public Task<GetManifestByIdResponseBody> GetManifestById(string manifestId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetManifestByIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetManifestByIdResponseBody>> GetManifestById(string manifestId, CancellationToken cancellationToken = default)
     {
         return GetManifestById(_client, manifestId, cancellationToken);
     }
@@ -194,8 +195,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="manifestId">The Manifest Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetManifestByIdResponseBody)</returns>
-    public async Task<GetManifestByIdResponseBody> GetManifestById(HttpClient methodClient, string manifestId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetManifestByIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetManifestByIdResponseBody>> GetManifestById(HttpClient methodClient, string manifestId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'manifestId' is set
         if (manifestId == null)
@@ -210,9 +211,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ManifestsApi.GetManifestById";
 
-        var result = await SendHttpRequestAsync<GetManifestByIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetManifestByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetManifestByIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -222,8 +224,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="manifestRequestId">The Manifest Request Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateManifestResponseBody)</returns>
-    public Task<CreateManifestResponseBody> GetManifestRequestById(string manifestRequestId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateManifestResponseBody)</returns>
+    public Task<ShipEngineResponse<CreateManifestResponseBody>> GetManifestRequestById(string manifestRequestId, CancellationToken cancellationToken = default)
     {
         return GetManifestRequestById(_client, manifestRequestId, cancellationToken);
     }
@@ -236,8 +238,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="manifestRequestId">The Manifest Request Id</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateManifestResponseBody)</returns>
-    public async Task<CreateManifestResponseBody> GetManifestRequestById(HttpClient methodClient, string manifestRequestId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateManifestResponseBody)</returns>
+    public async Task<ShipEngineResponse<CreateManifestResponseBody>> GetManifestRequestById(HttpClient methodClient, string manifestRequestId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'manifestRequestId' is set
         if (manifestRequestId == null)
@@ -252,9 +254,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ManifestsApi.GetManifestRequestById";
 
-        var result = await SendHttpRequestAsync<CreateManifestResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<CreateManifestResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<CreateManifestResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -272,8 +275,8 @@ public partial class ShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListManifestsResponseBody)</returns>
-    public Task<ListManifestsResponseBody> ListManifests(DateTimeOffset? shipDateStart = default, DateTimeOffset? shipDateEnd = default, DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, List<string>? labelIds = default, string? warehouseId = default, string? carrierId = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListManifestsResponseBody)</returns>
+    public Task<ShipEngineResponse<ListManifestsResponseBody>> ListManifests(DateTimeOffset? shipDateStart = default, DateTimeOffset? shipDateEnd = default, DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, List<string>? labelIds = default, string? warehouseId = default, string? carrierId = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
     {
         return ListManifests(_client, shipDateStart, shipDateEnd, createdAtStart, createdAtEnd, labelIds, warehouseId, carrierId, page, pageSize, cancellationToken);
     }
@@ -294,8 +297,8 @@ public partial class ShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListManifestsResponseBody)</returns>
-    public async Task<ListManifestsResponseBody> ListManifests(HttpClient methodClient, DateTimeOffset? shipDateStart = default, DateTimeOffset? shipDateEnd = default, DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, List<string>? labelIds = default, string? warehouseId = default, string? carrierId = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListManifestsResponseBody)</returns>
+    public async Task<ShipEngineResponse<ListManifestsResponseBody>> ListManifests(HttpClient methodClient, DateTimeOffset? shipDateStart = default, DateTimeOffset? shipDateEnd = default, DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, List<string>? labelIds = default, string? warehouseId = default, string? carrierId = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/manifests");
@@ -339,9 +342,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ManifestsApi.ListManifests";
 
-        var result = await SendHttpRequestAsync<ListManifestsResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ListManifestsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ListManifestsResponseBody>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/ManifestsApi.cs
+++ b/ShipEngineSDK/Api/ManifestsApi.cs
@@ -168,10 +168,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ManifestsApi.CreateManifest";
 
-        var (data, response) = await GetHttpResponse<CreateManifestResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<CreateManifestResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<CreateManifestResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -211,10 +208,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ManifestsApi.GetManifestById";
 
-        var (data, response) = await GetHttpResponse<GetManifestByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetManifestByIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetManifestByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -254,10 +248,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ManifestsApi.GetManifestRequestById";
 
-        var (data, response) = await GetHttpResponse<CreateManifestResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<CreateManifestResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<CreateManifestResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -342,10 +333,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ManifestsApi.ListManifests";
 
-        var (data, response) = await GetHttpResponse<ListManifestsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ListManifestsResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ListManifestsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/PackagePickupsApi.cs
+++ b/ShipEngineSDK/Api/PackagePickupsApi.cs
@@ -162,10 +162,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackagePickupsApi.DeleteScheduledPickup";
 
-        var (data, response) = await GetHttpResponse<DeletePickupByIdResponseBody>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<DeletePickupByIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<DeletePickupByIdResponseBody>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -205,10 +202,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackagePickupsApi.GetPickupById";
 
-        var (data, response) = await GetHttpResponse<GetPickupByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetPickupByIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetPickupByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -275,10 +269,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackagePickupsApi.ListScheduledPickups";
 
-        var (data, response) = await GetHttpResponse<GetPickupsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetPickupsResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetPickupsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -318,10 +309,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackagePickupsApi.SchedulePickup";
 
-        var (data, response) = await GetHttpResponse<SchedulePickupResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<SchedulePickupResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<SchedulePickupResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/PackagePickupsApi.cs
+++ b/ShipEngineSDK/Api/PackagePickupsApi.cs
@@ -31,8 +31,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="pickupId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (DeletePickupByIdResponseBody)</returns>
-    Task<DeletePickupByIdResponseBody> DeleteScheduledPickup(string pickupId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (DeletePickupByIdResponseBody)</returns>
+    Task<ShipEngineResponse<DeletePickupByIdResponseBody>> DeleteScheduledPickup(string pickupId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete a Scheduled Pickup Delete a previously-scheduled pickup by ID
@@ -42,8 +42,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="pickupId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (DeletePickupByIdResponseBody)</returns>
-    Task<DeletePickupByIdResponseBody> DeleteScheduledPickup(HttpClient methodClient, string pickupId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (DeletePickupByIdResponseBody)</returns>
+    Task<ShipEngineResponse<DeletePickupByIdResponseBody>> DeleteScheduledPickup(HttpClient methodClient, string pickupId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Pickup By ID Get Pickup By ID
@@ -52,8 +52,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="pickupId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetPickupByIdResponseBody)</returns>
-    Task<GetPickupByIdResponseBody> GetPickupById(string pickupId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetPickupByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetPickupByIdResponseBody>> GetPickupById(string pickupId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Pickup By ID Get Pickup By ID
@@ -63,8 +63,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="pickupId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetPickupByIdResponseBody)</returns>
-    Task<GetPickupByIdResponseBody> GetPickupById(HttpClient methodClient, string pickupId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetPickupByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetPickupByIdResponseBody>> GetPickupById(HttpClient methodClient, string pickupId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Scheduled Pickups List all pickups that have been scheduled for this carrier
@@ -78,8 +78,8 @@ public partial interface IShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetPickupsResponseBody)</returns>
-    Task<GetPickupsResponseBody> ListScheduledPickups(DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, string? carrierId, string? warehouseId, int? page, int? pageSize, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetPickupsResponseBody)</returns>
+    Task<ShipEngineResponse<GetPickupsResponseBody>> ListScheduledPickups(DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, string? carrierId, string? warehouseId, int? page, int? pageSize, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Scheduled Pickups List all pickups that have been scheduled for this carrier
@@ -94,8 +94,8 @@ public partial interface IShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetPickupsResponseBody)</returns>
-    Task<GetPickupsResponseBody> ListScheduledPickups(HttpClient methodClient, DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, string? carrierId, string? warehouseId, int? page, int? pageSize, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetPickupsResponseBody)</returns>
+    Task<ShipEngineResponse<GetPickupsResponseBody>> ListScheduledPickups(HttpClient methodClient, DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, string? carrierId, string? warehouseId, int? page, int? pageSize, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Schedule a Pickup Schedule a package pickup with a carrier
@@ -104,8 +104,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="schedulePickupRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (SchedulePickupResponseBody)</returns>
-    Task<SchedulePickupResponseBody> SchedulePickup(SchedulePickupRequestBody schedulePickupRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (SchedulePickupResponseBody)</returns>
+    Task<ShipEngineResponse<SchedulePickupResponseBody>> SchedulePickup(SchedulePickupRequestBody schedulePickupRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Schedule a Pickup Schedule a package pickup with a carrier
@@ -115,8 +115,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="schedulePickupRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (SchedulePickupResponseBody)</returns>
-    Task<SchedulePickupResponseBody> SchedulePickup(HttpClient methodClient, SchedulePickupRequestBody schedulePickupRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (SchedulePickupResponseBody)</returns>
+    Task<ShipEngineResponse<SchedulePickupResponseBody>> SchedulePickup(HttpClient methodClient, SchedulePickupRequestBody schedulePickupRequestBody, CancellationToken cancellationToken = default);
 
 }
 
@@ -132,8 +132,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="pickupId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (DeletePickupByIdResponseBody)</returns>
-    public Task<DeletePickupByIdResponseBody> DeleteScheduledPickup(string pickupId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (DeletePickupByIdResponseBody)</returns>
+    public Task<ShipEngineResponse<DeletePickupByIdResponseBody>> DeleteScheduledPickup(string pickupId, CancellationToken cancellationToken = default)
     {
         return DeleteScheduledPickup(_client, pickupId, cancellationToken);
     }
@@ -146,8 +146,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="pickupId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (DeletePickupByIdResponseBody)</returns>
-    public async Task<DeletePickupByIdResponseBody> DeleteScheduledPickup(HttpClient methodClient, string pickupId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (DeletePickupByIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<DeletePickupByIdResponseBody>> DeleteScheduledPickup(HttpClient methodClient, string pickupId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'pickupId' is set
         if (pickupId == null)
@@ -162,9 +162,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackagePickupsApi.DeleteScheduledPickup";
 
-        var result = await SendHttpRequestAsync<DeletePickupByIdResponseBody>(HttpMethods.Delete, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<DeletePickupByIdResponseBody>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<DeletePickupByIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -174,8 +175,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="pickupId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetPickupByIdResponseBody)</returns>
-    public Task<GetPickupByIdResponseBody> GetPickupById(string pickupId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetPickupByIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetPickupByIdResponseBody>> GetPickupById(string pickupId, CancellationToken cancellationToken = default)
     {
         return GetPickupById(_client, pickupId, cancellationToken);
     }
@@ -188,8 +189,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="pickupId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetPickupByIdResponseBody)</returns>
-    public async Task<GetPickupByIdResponseBody> GetPickupById(HttpClient methodClient, string pickupId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetPickupByIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetPickupByIdResponseBody>> GetPickupById(HttpClient methodClient, string pickupId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'pickupId' is set
         if (pickupId == null)
@@ -204,9 +205,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackagePickupsApi.GetPickupById";
 
-        var result = await SendHttpRequestAsync<GetPickupByIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetPickupByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetPickupByIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -221,8 +223,8 @@ public partial class ShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetPickupsResponseBody)</returns>
-    public Task<GetPickupsResponseBody> ListScheduledPickups(DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, string? carrierId = default, string? warehouseId = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetPickupsResponseBody)</returns>
+    public Task<ShipEngineResponse<GetPickupsResponseBody>> ListScheduledPickups(DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, string? carrierId = default, string? warehouseId = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
     {
         return ListScheduledPickups(_client, createdAtStart, createdAtEnd, carrierId, warehouseId, page, pageSize, cancellationToken);
     }
@@ -240,8 +242,8 @@ public partial class ShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetPickupsResponseBody)</returns>
-    public async Task<GetPickupsResponseBody> ListScheduledPickups(HttpClient methodClient, DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, string? carrierId = default, string? warehouseId = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetPickupsResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetPickupsResponseBody>> ListScheduledPickups(HttpClient methodClient, DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, string? carrierId = default, string? warehouseId = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/pickups");
@@ -273,9 +275,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackagePickupsApi.ListScheduledPickups";
 
-        var result = await SendHttpRequestAsync<GetPickupsResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetPickupsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetPickupsResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -285,8 +288,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="schedulePickupRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (SchedulePickupResponseBody)</returns>
-    public Task<SchedulePickupResponseBody> SchedulePickup(SchedulePickupRequestBody schedulePickupRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (SchedulePickupResponseBody)</returns>
+    public Task<ShipEngineResponse<SchedulePickupResponseBody>> SchedulePickup(SchedulePickupRequestBody schedulePickupRequestBody, CancellationToken cancellationToken = default)
     {
         return SchedulePickup(_client, schedulePickupRequestBody, cancellationToken);
     }
@@ -299,8 +302,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="schedulePickupRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (SchedulePickupResponseBody)</returns>
-    public async Task<SchedulePickupResponseBody> SchedulePickup(HttpClient methodClient, SchedulePickupRequestBody schedulePickupRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (SchedulePickupResponseBody)</returns>
+    public async Task<ShipEngineResponse<SchedulePickupResponseBody>> SchedulePickup(HttpClient methodClient, SchedulePickupRequestBody schedulePickupRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'schedulePickupRequestBody' is set
         if (schedulePickupRequestBody == null)
@@ -315,9 +318,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackagePickupsApi.SchedulePickup";
 
-        var result = await SendHttpRequestAsync<SchedulePickupResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<SchedulePickupResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<SchedulePickupResponseBody>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/PackageTypesApi.cs
+++ b/ShipEngineSDK/Api/PackageTypesApi.cs
@@ -173,10 +173,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackageTypesApi.CreatePackageType";
 
-        var (data, response) = await GetHttpResponse<CreatePackageTypeResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<CreatePackageTypeResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<CreatePackageTypeResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -216,10 +213,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackageTypesApi.DeletePackageType";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -259,10 +253,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackageTypesApi.GetPackageTypeById";
 
-        var (data, response) = await GetHttpResponse<GetPackageTypeByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetPackageTypeByIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetPackageTypeByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -293,10 +284,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackageTypesApi.ListPackageTypes";
 
-        var (data, response) = await GetHttpResponse<ListPackageTypesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ListPackageTypesResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ListPackageTypesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -345,10 +333,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackageTypesApi.UpdatePackageType";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/PackageTypesApi.cs
+++ b/ShipEngineSDK/Api/PackageTypesApi.cs
@@ -31,8 +31,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createPackageTypeRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreatePackageTypeResponseBody)</returns>
-    Task<CreatePackageTypeResponseBody> CreatePackageType(CreatePackageTypeRequestBody createPackageTypeRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreatePackageTypeResponseBody)</returns>
+    Task<ShipEngineResponse<CreatePackageTypeResponseBody>> CreatePackageType(CreatePackageTypeRequestBody createPackageTypeRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create Custom Package Type Create a custom package type to better assist in getting accurate rate estimates
@@ -42,8 +42,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createPackageTypeRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreatePackageTypeResponseBody)</returns>
-    Task<CreatePackageTypeResponseBody> CreatePackageType(HttpClient methodClient, CreatePackageTypeRequestBody createPackageTypeRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreatePackageTypeResponseBody)</returns>
+    Task<ShipEngineResponse<CreatePackageTypeResponseBody>> CreatePackageType(HttpClient methodClient, CreatePackageTypeRequestBody createPackageTypeRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete A Custom Package By ID Delete a custom package using the ID
@@ -52,8 +52,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="packageId">Package ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DeletePackageType(string packageId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DeletePackageType(string packageId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete A Custom Package By ID Delete a custom package using the ID
@@ -63,8 +63,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="packageId">Package ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DeletePackageType(HttpClient methodClient, string packageId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DeletePackageType(HttpClient methodClient, string packageId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Custom Package Type By ID Get Custom Package Type by ID
@@ -73,8 +73,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="packageId">Package ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetPackageTypeByIdResponseBody)</returns>
-    Task<GetPackageTypeByIdResponseBody> GetPackageTypeById(string packageId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetPackageTypeByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetPackageTypeByIdResponseBody>> GetPackageTypeById(string packageId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Custom Package Type By ID Get Custom Package Type by ID
@@ -84,8 +84,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="packageId">Package ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetPackageTypeByIdResponseBody)</returns>
-    Task<GetPackageTypeByIdResponseBody> GetPackageTypeById(HttpClient methodClient, string packageId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetPackageTypeByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetPackageTypeByIdResponseBody>> GetPackageTypeById(HttpClient methodClient, string packageId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Custom Package Types List the custom package types associated with the account
@@ -93,8 +93,8 @@ public partial interface IShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListPackageTypesResponseBody)</returns>
-    Task<ListPackageTypesResponseBody> ListPackageTypes(CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListPackageTypesResponseBody)</returns>
+    Task<ShipEngineResponse<ListPackageTypesResponseBody>> ListPackageTypes(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Custom Package Types List the custom package types associated with the account
@@ -103,8 +103,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListPackageTypesResponseBody)</returns>
-    Task<ListPackageTypesResponseBody> ListPackageTypes(HttpClient methodClient, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListPackageTypesResponseBody)</returns>
+    Task<ShipEngineResponse<ListPackageTypesResponseBody>> ListPackageTypes(HttpClient methodClient, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Custom Package Type By ID Update the custom package type object by ID
@@ -114,8 +114,8 @@ public partial interface IShipEngine
     /// <param name="updatePackageTypeRequestBody"></param>
     /// <param name="packageId">Package ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdatePackageType(UpdatePackageTypeRequestBody updatePackageTypeRequestBody, string packageId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdatePackageType(UpdatePackageTypeRequestBody updatePackageTypeRequestBody, string packageId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Custom Package Type By ID Update the custom package type object by ID
@@ -126,8 +126,8 @@ public partial interface IShipEngine
     /// <param name="updatePackageTypeRequestBody"></param>
     /// <param name="packageId">Package ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdatePackageType(HttpClient methodClient, UpdatePackageTypeRequestBody updatePackageTypeRequestBody, string packageId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdatePackageType(HttpClient methodClient, UpdatePackageTypeRequestBody updatePackageTypeRequestBody, string packageId, CancellationToken cancellationToken = default);
 
 }
 
@@ -143,8 +143,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createPackageTypeRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreatePackageTypeResponseBody)</returns>
-    public Task<CreatePackageTypeResponseBody> CreatePackageType(CreatePackageTypeRequestBody createPackageTypeRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreatePackageTypeResponseBody)</returns>
+    public Task<ShipEngineResponse<CreatePackageTypeResponseBody>> CreatePackageType(CreatePackageTypeRequestBody createPackageTypeRequestBody, CancellationToken cancellationToken = default)
     {
         return CreatePackageType(_client, createPackageTypeRequestBody, cancellationToken);
     }
@@ -157,8 +157,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createPackageTypeRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreatePackageTypeResponseBody)</returns>
-    public async Task<CreatePackageTypeResponseBody> CreatePackageType(HttpClient methodClient, CreatePackageTypeRequestBody createPackageTypeRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreatePackageTypeResponseBody)</returns>
+    public async Task<ShipEngineResponse<CreatePackageTypeResponseBody>> CreatePackageType(HttpClient methodClient, CreatePackageTypeRequestBody createPackageTypeRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'createPackageTypeRequestBody' is set
         if (createPackageTypeRequestBody == null)
@@ -173,9 +173,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackageTypesApi.CreatePackageType";
 
-        var result = await SendHttpRequestAsync<CreatePackageTypeResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<CreatePackageTypeResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<CreatePackageTypeResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -185,8 +186,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="packageId">Package ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> DeletePackageType(string packageId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> DeletePackageType(string packageId, CancellationToken cancellationToken = default)
     {
         return DeletePackageType(_client, packageId, cancellationToken);
     }
@@ -199,8 +200,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="packageId">Package ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> DeletePackageType(HttpClient methodClient, string packageId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> DeletePackageType(HttpClient methodClient, string packageId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'packageId' is set
         if (packageId == null)
@@ -215,9 +216,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackageTypesApi.DeletePackageType";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Delete, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -227,8 +229,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="packageId">Package ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetPackageTypeByIdResponseBody)</returns>
-    public Task<GetPackageTypeByIdResponseBody> GetPackageTypeById(string packageId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetPackageTypeByIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetPackageTypeByIdResponseBody>> GetPackageTypeById(string packageId, CancellationToken cancellationToken = default)
     {
         return GetPackageTypeById(_client, packageId, cancellationToken);
     }
@@ -241,8 +243,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="packageId">Package ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetPackageTypeByIdResponseBody)</returns>
-    public async Task<GetPackageTypeByIdResponseBody> GetPackageTypeById(HttpClient methodClient, string packageId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetPackageTypeByIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetPackageTypeByIdResponseBody>> GetPackageTypeById(HttpClient methodClient, string packageId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'packageId' is set
         if (packageId == null)
@@ -257,9 +259,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackageTypesApi.GetPackageTypeById";
 
-        var result = await SendHttpRequestAsync<GetPackageTypeByIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetPackageTypeByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetPackageTypeByIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -268,8 +271,8 @@ public partial class ShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListPackageTypesResponseBody)</returns>
-    public Task<ListPackageTypesResponseBody> ListPackageTypes(CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListPackageTypesResponseBody)</returns>
+    public Task<ShipEngineResponse<ListPackageTypesResponseBody>> ListPackageTypes(CancellationToken cancellationToken = default)
     {
         return ListPackageTypes(_client, cancellationToken);
     }
@@ -281,8 +284,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListPackageTypesResponseBody)</returns>
-    public async Task<ListPackageTypesResponseBody> ListPackageTypes(HttpClient methodClient, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListPackageTypesResponseBody)</returns>
+    public async Task<ShipEngineResponse<ListPackageTypesResponseBody>> ListPackageTypes(HttpClient methodClient, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/packages");
@@ -290,9 +293,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackageTypesApi.ListPackageTypes";
 
-        var result = await SendHttpRequestAsync<ListPackageTypesResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ListPackageTypesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ListPackageTypesResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -303,8 +307,8 @@ public partial class ShipEngine
     /// <param name="updatePackageTypeRequestBody"></param>
     /// <param name="packageId">Package ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> UpdatePackageType(UpdatePackageTypeRequestBody updatePackageTypeRequestBody, string packageId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> UpdatePackageType(UpdatePackageTypeRequestBody updatePackageTypeRequestBody, string packageId, CancellationToken cancellationToken = default)
     {
         return UpdatePackageType(_client, updatePackageTypeRequestBody, packageId, cancellationToken);
     }
@@ -318,8 +322,8 @@ public partial class ShipEngine
     /// <param name="updatePackageTypeRequestBody"></param>
     /// <param name="packageId">Package ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> UpdatePackageType(HttpClient methodClient, UpdatePackageTypeRequestBody updatePackageTypeRequestBody, string packageId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> UpdatePackageType(HttpClient methodClient, UpdatePackageTypeRequestBody updatePackageTypeRequestBody, string packageId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'updatePackageTypeRequestBody' is set
         if (updatePackageTypeRequestBody == null)
@@ -341,9 +345,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "PackageTypesApi.UpdatePackageType";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/RatesApi.cs
+++ b/ShipEngineSDK/Api/RatesApi.cs
@@ -31,8 +31,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="calculateRatesRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CalculateRatesResponseBody)</returns>
-    Task<CalculateRatesResponseBody> CalculateRates(CalculateRatesRequestBody calculateRatesRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CalculateRatesResponseBody)</returns>
+    Task<ShipEngineResponse<CalculateRatesResponseBody>> CalculateRates(CalculateRatesRequestBody calculateRatesRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Shipping Rates It&#39;s not uncommon that you want to give your customer the choice between whether they want to ship the fastest, cheapest, or the most trusted route. Most companies don&#39;t solely ship things using a single shipping option; so we provide functionality to show you all your options! 
@@ -42,8 +42,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="calculateRatesRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CalculateRatesResponseBody)</returns>
-    Task<CalculateRatesResponseBody> CalculateRates(HttpClient methodClient, CalculateRatesRequestBody calculateRatesRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CalculateRatesResponseBody)</returns>
+    Task<ShipEngineResponse<CalculateRatesResponseBody>> CalculateRates(HttpClient methodClient, CalculateRatesRequestBody calculateRatesRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Bulk Rates Get Bulk Shipment Rates
@@ -52,8 +52,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="compareBulkRatesRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;BulkRate&gt;)</returns>
-    Task<List<BulkRate>> CompareBulkRates(CompareBulkRatesRequestBody compareBulkRatesRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (List&lt;BulkRate&gt;)</returns>
+    Task<ShipEngineResponse<List<BulkRate>>> CompareBulkRates(CompareBulkRatesRequestBody compareBulkRatesRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Bulk Rates Get Bulk Shipment Rates
@@ -63,8 +63,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="compareBulkRatesRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;BulkRate&gt;)</returns>
-    Task<List<BulkRate>> CompareBulkRates(HttpClient methodClient, CompareBulkRatesRequestBody compareBulkRatesRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (List&lt;BulkRate&gt;)</returns>
+    Task<ShipEngineResponse<List<BulkRate>>> CompareBulkRates(HttpClient methodClient, CompareBulkRatesRequestBody compareBulkRatesRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Estimate Rates Get Rate Estimates
@@ -73,8 +73,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="estimateRatesRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;RateEstimate&gt;)</returns>
-    Task<List<RateEstimate>> EstimateRates(EstimateRatesRequestBody estimateRatesRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (List&lt;RateEstimate&gt;)</returns>
+    Task<ShipEngineResponse<List<RateEstimate>>> EstimateRates(EstimateRatesRequestBody estimateRatesRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Estimate Rates Get Rate Estimates
@@ -84,8 +84,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="estimateRatesRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;RateEstimate&gt;)</returns>
-    Task<List<RateEstimate>> EstimateRates(HttpClient methodClient, EstimateRatesRequestBody estimateRatesRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (List&lt;RateEstimate&gt;)</returns>
+    Task<ShipEngineResponse<List<RateEstimate>>> EstimateRates(HttpClient methodClient, EstimateRatesRequestBody estimateRatesRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Rate By ID Retrieve a previously queried rate by its ID
@@ -94,8 +94,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="rateId">Rate ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetRateByIdResponseBody)</returns>
-    Task<GetRateByIdResponseBody> GetRateById(string rateId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetRateByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetRateByIdResponseBody>> GetRateById(string rateId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Rate By ID Retrieve a previously queried rate by its ID
@@ -105,8 +105,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="rateId">Rate ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetRateByIdResponseBody)</returns>
-    Task<GetRateByIdResponseBody> GetRateById(HttpClient methodClient, string rateId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetRateByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetRateByIdResponseBody>> GetRateById(HttpClient methodClient, string rateId, CancellationToken cancellationToken = default);
 
 }
 
@@ -122,8 +122,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="calculateRatesRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CalculateRatesResponseBody)</returns>
-    public Task<CalculateRatesResponseBody> CalculateRates(CalculateRatesRequestBody calculateRatesRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CalculateRatesResponseBody)</returns>
+    public Task<ShipEngineResponse<CalculateRatesResponseBody>> CalculateRates(CalculateRatesRequestBody calculateRatesRequestBody, CancellationToken cancellationToken = default)
     {
         return CalculateRates(_client, calculateRatesRequestBody, cancellationToken);
     }
@@ -136,8 +136,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="calculateRatesRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CalculateRatesResponseBody)</returns>
-    public async Task<CalculateRatesResponseBody> CalculateRates(HttpClient methodClient, CalculateRatesRequestBody calculateRatesRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CalculateRatesResponseBody)</returns>
+    public async Task<ShipEngineResponse<CalculateRatesResponseBody>> CalculateRates(HttpClient methodClient, CalculateRatesRequestBody calculateRatesRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'calculateRatesRequestBody' is set
         if (calculateRatesRequestBody == null)
@@ -152,9 +152,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "RatesApi.CalculateRates";
 
-        var result = await SendHttpRequestAsync<CalculateRatesResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<CalculateRatesResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<CalculateRatesResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -164,8 +165,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="compareBulkRatesRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;BulkRate&gt;)</returns>
-    public Task<List<BulkRate>> CompareBulkRates(CompareBulkRatesRequestBody compareBulkRatesRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (List&lt;BulkRate&gt;)</returns>
+    public Task<ShipEngineResponse<List<BulkRate>>> CompareBulkRates(CompareBulkRatesRequestBody compareBulkRatesRequestBody, CancellationToken cancellationToken = default)
     {
         return CompareBulkRates(_client, compareBulkRatesRequestBody, cancellationToken);
     }
@@ -178,8 +179,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="compareBulkRatesRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;BulkRate&gt;)</returns>
-    public async Task<List<BulkRate>> CompareBulkRates(HttpClient methodClient, CompareBulkRatesRequestBody compareBulkRatesRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (List&lt;BulkRate&gt;)</returns>
+    public async Task<ShipEngineResponse<List<BulkRate>>> CompareBulkRates(HttpClient methodClient, CompareBulkRatesRequestBody compareBulkRatesRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'compareBulkRatesRequestBody' is set
         if (compareBulkRatesRequestBody == null)
@@ -194,9 +195,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "RatesApi.CompareBulkRates";
 
-        var result = await SendHttpRequestAsync<List<BulkRate>>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<List<BulkRate>>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<List<BulkRate>>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -206,8 +208,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="estimateRatesRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;RateEstimate&gt;)</returns>
-    public Task<List<RateEstimate>> EstimateRates(EstimateRatesRequestBody estimateRatesRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (List&lt;RateEstimate&gt;)</returns>
+    public Task<ShipEngineResponse<List<RateEstimate>>> EstimateRates(EstimateRatesRequestBody estimateRatesRequestBody, CancellationToken cancellationToken = default)
     {
         return EstimateRates(_client, estimateRatesRequestBody, cancellationToken);
     }
@@ -220,8 +222,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="estimateRatesRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;RateEstimate&gt;)</returns>
-    public async Task<List<RateEstimate>> EstimateRates(HttpClient methodClient, EstimateRatesRequestBody estimateRatesRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (List&lt;RateEstimate&gt;)</returns>
+    public async Task<ShipEngineResponse<List<RateEstimate>>> EstimateRates(HttpClient methodClient, EstimateRatesRequestBody estimateRatesRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'estimateRatesRequestBody' is set
         if (estimateRatesRequestBody == null)
@@ -236,9 +238,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "RatesApi.EstimateRates";
 
-        var result = await SendHttpRequestAsync<List<RateEstimate>>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<List<RateEstimate>>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<List<RateEstimate>>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -248,8 +251,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="rateId">Rate ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetRateByIdResponseBody)</returns>
-    public Task<GetRateByIdResponseBody> GetRateById(string rateId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetRateByIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetRateByIdResponseBody>> GetRateById(string rateId, CancellationToken cancellationToken = default)
     {
         return GetRateById(_client, rateId, cancellationToken);
     }
@@ -262,8 +265,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="rateId">Rate ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetRateByIdResponseBody)</returns>
-    public async Task<GetRateByIdResponseBody> GetRateById(HttpClient methodClient, string rateId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetRateByIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetRateByIdResponseBody>> GetRateById(HttpClient methodClient, string rateId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'rateId' is set
         if (rateId == null)
@@ -278,9 +281,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "RatesApi.GetRateById";
 
-        var result = await SendHttpRequestAsync<GetRateByIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetRateByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetRateByIdResponseBody>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/RatesApi.cs
+++ b/ShipEngineSDK/Api/RatesApi.cs
@@ -152,10 +152,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "RatesApi.CalculateRates";
 
-        var (data, response) = await GetHttpResponse<CalculateRatesResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<CalculateRatesResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<CalculateRatesResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -195,10 +192,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "RatesApi.CompareBulkRates";
 
-        var (data, response) = await GetHttpResponse<List<BulkRate>>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<List<BulkRate>>(data, response.StatusCode, headers);
+        return await GetHttpResponse<List<BulkRate>>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -238,10 +232,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "RatesApi.EstimateRates";
 
-        var (data, response) = await GetHttpResponse<List<RateEstimate>>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<List<RateEstimate>>(data, response.StatusCode, headers);
+        return await GetHttpResponse<List<RateEstimate>>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -281,10 +272,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "RatesApi.GetRateById";
 
-        var (data, response) = await GetHttpResponse<GetRateByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetRateByIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetRateByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/ServicePointsApi.cs
+++ b/ShipEngineSDK/Api/ServicePointsApi.cs
@@ -132,10 +132,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ServicePointsApi.ServicePointsGetById";
 
-        var (data, response) = await GetHttpResponse<GetServicePointByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetServicePointByIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetServicePointByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -175,10 +172,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ServicePointsApi.ServicePointsList";
 
-        var (data, response) = await GetHttpResponse<ListServicePointsResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ListServicePointsResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ListServicePointsResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/ServicePointsApi.cs
+++ b/ShipEngineSDK/Api/ServicePointsApi.cs
@@ -33,8 +33,8 @@ public partial interface IShipEngine
     /// <param name="countryCode">A two-letter [ISO 3166-1 country code](https://en.wikipedia.org/wiki/ISO_3166-1) </param>
     /// <param name="servicePointId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetServicePointByIdResponseBody)</returns>
-    Task<GetServicePointByIdResponseBody> ServicePointsGetById(string carrierCode, string countryCode, string servicePointId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetServicePointByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetServicePointByIdResponseBody>> ServicePointsGetById(string carrierCode, string countryCode, string servicePointId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Service Point By ID Returns a carrier service point by using the service_point_id
@@ -46,8 +46,8 @@ public partial interface IShipEngine
     /// <param name="countryCode">A two-letter [ISO 3166-1 country code](https://en.wikipedia.org/wiki/ISO_3166-1) </param>
     /// <param name="servicePointId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetServicePointByIdResponseBody)</returns>
-    Task<GetServicePointByIdResponseBody> ServicePointsGetById(HttpClient methodClient, string carrierCode, string countryCode, string servicePointId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetServicePointByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetServicePointByIdResponseBody>> ServicePointsGetById(HttpClient methodClient, string carrierCode, string countryCode, string servicePointId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Service Points List carrier service points by location
@@ -56,8 +56,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="getServicePointsRequest"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListServicePointsResponseBody)</returns>
-    Task<ListServicePointsResponseBody> ServicePointsList(GetServicePointsRequest getServicePointsRequest, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListServicePointsResponseBody)</returns>
+    Task<ShipEngineResponse<ListServicePointsResponseBody>> ServicePointsList(GetServicePointsRequest getServicePointsRequest, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Service Points List carrier service points by location
@@ -67,8 +67,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="getServicePointsRequest"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListServicePointsResponseBody)</returns>
-    Task<ListServicePointsResponseBody> ServicePointsList(HttpClient methodClient, GetServicePointsRequest getServicePointsRequest, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListServicePointsResponseBody)</returns>
+    Task<ShipEngineResponse<ListServicePointsResponseBody>> ServicePointsList(HttpClient methodClient, GetServicePointsRequest getServicePointsRequest, CancellationToken cancellationToken = default);
 
 }
 
@@ -86,8 +86,8 @@ public partial class ShipEngine
     /// <param name="countryCode">A two-letter [ISO 3166-1 country code](https://en.wikipedia.org/wiki/ISO_3166-1) </param>
     /// <param name="servicePointId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetServicePointByIdResponseBody)</returns>
-    public Task<GetServicePointByIdResponseBody> ServicePointsGetById(string carrierCode, string countryCode, string servicePointId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetServicePointByIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetServicePointByIdResponseBody>> ServicePointsGetById(string carrierCode, string countryCode, string servicePointId, CancellationToken cancellationToken = default)
     {
         return ServicePointsGetById(_client, carrierCode, countryCode, servicePointId, cancellationToken);
     }
@@ -102,8 +102,8 @@ public partial class ShipEngine
     /// <param name="countryCode">A two-letter [ISO 3166-1 country code](https://en.wikipedia.org/wiki/ISO_3166-1) </param>
     /// <param name="servicePointId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetServicePointByIdResponseBody)</returns>
-    public async Task<GetServicePointByIdResponseBody> ServicePointsGetById(HttpClient methodClient, string carrierCode, string countryCode, string servicePointId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetServicePointByIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetServicePointByIdResponseBody>> ServicePointsGetById(HttpClient methodClient, string carrierCode, string countryCode, string servicePointId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'carrierCode' is set
         if (carrierCode == null)
@@ -132,9 +132,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ServicePointsApi.ServicePointsGetById";
 
-        var result = await SendHttpRequestAsync<GetServicePointByIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetServicePointByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetServicePointByIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -144,8 +145,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="getServicePointsRequest"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListServicePointsResponseBody)</returns>
-    public Task<ListServicePointsResponseBody> ServicePointsList(GetServicePointsRequest getServicePointsRequest, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListServicePointsResponseBody)</returns>
+    public Task<ShipEngineResponse<ListServicePointsResponseBody>> ServicePointsList(GetServicePointsRequest getServicePointsRequest, CancellationToken cancellationToken = default)
     {
         return ServicePointsList(_client, getServicePointsRequest, cancellationToken);
     }
@@ -158,8 +159,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="getServicePointsRequest"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListServicePointsResponseBody)</returns>
-    public async Task<ListServicePointsResponseBody> ServicePointsList(HttpClient methodClient, GetServicePointsRequest getServicePointsRequest, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListServicePointsResponseBody)</returns>
+    public async Task<ShipEngineResponse<ListServicePointsResponseBody>> ServicePointsList(HttpClient methodClient, GetServicePointsRequest getServicePointsRequest, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'getServicePointsRequest' is set
         if (getServicePointsRequest == null)
@@ -174,9 +175,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ServicePointsApi.ServicePointsList";
 
-        var result = await SendHttpRequestAsync<ListServicePointsResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ListServicePointsResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ListServicePointsResponseBody>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/ShipmentsApi.cs
+++ b/ShipEngineSDK/Api/ShipmentsApi.cs
@@ -350,10 +350,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.CancelShipments";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -393,10 +390,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.CreateShipments";
 
-        var (data, response) = await GetHttpResponse<CreateShipmentsResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<CreateShipmentsResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<CreateShipmentsResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -436,10 +430,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.GetShipmentByExternalId";
 
-        var (data, response) = await GetHttpResponse<GetShipmentByExternalIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetShipmentByExternalIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetShipmentByExternalIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -479,10 +470,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.GetShipmentById";
 
-        var (data, response) = await GetHttpResponse<GetShipmentByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetShipmentByIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetShipmentByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -528,10 +516,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.ListShipmentRates";
 
-        var (data, response) = await GetHttpResponse<ListShipmentRatesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ListShipmentRatesResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ListShipmentRatesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -634,10 +619,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.ListShipments";
 
-        var (data, response) = await GetHttpResponse<ListShipmentsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ListShipmentsResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ListShipmentsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -677,10 +659,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.ParseShipment";
 
-        var (data, response) = await GetHttpResponse<ParseShipmentResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ParseShipmentResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ParseShipmentResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -720,10 +699,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.ShipmentsListTags";
 
-        var (data, response) = await GetHttpResponse<TagShipmentResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<TagShipmentResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<TagShipmentResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -763,10 +739,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.ShipmentsUpdateTags";
 
-        var (data, response) = await GetHttpResponse<Object>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<Object>(data, response.StatusCode, headers);
+        return await GetHttpResponse<Object>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -815,10 +788,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.TagShipment";
 
-        var (data, response) = await GetHttpResponse<TagShipmentResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<TagShipmentResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<TagShipmentResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -867,10 +837,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.UntagShipment";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -919,10 +886,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.UpdateShipment";
 
-        var (data, response) = await GetHttpResponse<UpdateShipmentResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<UpdateShipmentResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<UpdateShipmentResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/ShipmentsApi.cs
+++ b/ShipEngineSDK/Api/ShipmentsApi.cs
@@ -31,8 +31,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> CancelShipments(string shipmentId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> CancelShipments(string shipmentId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Cancel a Shipment Mark a shipment cancelled, if it is no longer needed or being used by your organized. Any label associated with the shipment needs to be voided first An example use case would be if a batch label creation job is going to run at a set time and only queries &#x60;pending&#x60; shipments. Marking a shipment as cancelled would remove it from this process 
@@ -42,8 +42,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> CancelShipments(HttpClient methodClient, string shipmentId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> CancelShipments(HttpClient methodClient, string shipmentId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create Shipments Create one or multiple shipments.
@@ -52,8 +52,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createShipmentsRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateShipmentsResponseBody)</returns>
-    Task<CreateShipmentsResponseBody> CreateShipments(CreateShipmentsRequestBody createShipmentsRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateShipmentsResponseBody)</returns>
+    Task<ShipEngineResponse<CreateShipmentsResponseBody>> CreateShipments(CreateShipmentsRequestBody createShipmentsRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create Shipments Create one or multiple shipments.
@@ -63,8 +63,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createShipmentsRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateShipmentsResponseBody)</returns>
-    Task<CreateShipmentsResponseBody> CreateShipments(HttpClient methodClient, CreateShipmentsRequestBody createShipmentsRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateShipmentsResponseBody)</returns>
+    Task<ShipEngineResponse<CreateShipmentsResponseBody>> CreateShipments(HttpClient methodClient, CreateShipmentsRequestBody createShipmentsRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Shipment By External ID Query Shipments created using your own custom ID convention using this endpint
@@ -73,8 +73,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="externalShipmentId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetShipmentByExternalIdResponseBody)</returns>
-    Task<GetShipmentByExternalIdResponseBody> GetShipmentByExternalId(string externalShipmentId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetShipmentByExternalIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetShipmentByExternalIdResponseBody>> GetShipmentByExternalId(string externalShipmentId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Shipment By External ID Query Shipments created using your own custom ID convention using this endpint
@@ -84,8 +84,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="externalShipmentId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetShipmentByExternalIdResponseBody)</returns>
-    Task<GetShipmentByExternalIdResponseBody> GetShipmentByExternalId(HttpClient methodClient, string externalShipmentId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetShipmentByExternalIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetShipmentByExternalIdResponseBody>> GetShipmentByExternalId(HttpClient methodClient, string externalShipmentId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Shipment By ID Get an individual shipment based on its ID
@@ -94,8 +94,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetShipmentByIdResponseBody)</returns>
-    Task<GetShipmentByIdResponseBody> GetShipmentById(string shipmentId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetShipmentByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetShipmentByIdResponseBody>> GetShipmentById(string shipmentId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Shipment By ID Get an individual shipment based on its ID
@@ -105,8 +105,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetShipmentByIdResponseBody)</returns>
-    Task<GetShipmentByIdResponseBody> GetShipmentById(HttpClient methodClient, string shipmentId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetShipmentByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetShipmentByIdResponseBody>> GetShipmentById(HttpClient methodClient, string shipmentId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Shipment Rates Get Rates for the shipment information associated with the shipment ID
@@ -116,8 +116,8 @@ public partial interface IShipEngine
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="createdAtStart">Used to create a filter for when a resource was created (ex. A shipment that was created after a certain time) (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListShipmentRatesResponseBody)</returns>
-    Task<ListShipmentRatesResponseBody> ListShipmentRates(string shipmentId, DateTimeOffset? createdAtStart, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListShipmentRatesResponseBody)</returns>
+    Task<ShipEngineResponse<ListShipmentRatesResponseBody>> ListShipmentRates(string shipmentId, DateTimeOffset? createdAtStart, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Shipment Rates Get Rates for the shipment information associated with the shipment ID
@@ -128,8 +128,8 @@ public partial interface IShipEngine
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="createdAtStart">Used to create a filter for when a resource was created (ex. A shipment that was created after a certain time) (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListShipmentRatesResponseBody)</returns>
-    Task<ListShipmentRatesResponseBody> ListShipmentRates(HttpClient methodClient, string shipmentId, DateTimeOffset? createdAtStart, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListShipmentRatesResponseBody)</returns>
+    Task<ShipEngineResponse<ListShipmentRatesResponseBody>> ListShipmentRates(HttpClient methodClient, string shipmentId, DateTimeOffset? createdAtStart, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Shipments Get list of Shipments
@@ -149,8 +149,8 @@ public partial interface IShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListShipmentsResponseBody)</returns>
-    Task<ListShipmentsResponseBody> ListShipments(DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, DateTimeOffset? modifiedAtStart, DateTimeOffset? modifiedAtEnd, ShipmentStatus? shipmentStatus, ShipmentsSortBy? sortBy, SortDir? sortDir, string? batchId, string? tag, string? salesOrderId, int? page, int? pageSize, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListShipmentsResponseBody)</returns>
+    Task<ShipEngineResponse<ListShipmentsResponseBody>> ListShipments(DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, DateTimeOffset? modifiedAtStart, DateTimeOffset? modifiedAtEnd, ShipmentStatus? shipmentStatus, ShipmentsSortBy? sortBy, SortDir? sortDir, string? batchId, string? tag, string? salesOrderId, int? page, int? pageSize, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Shipments Get list of Shipments
@@ -171,8 +171,8 @@ public partial interface IShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListShipmentsResponseBody)</returns>
-    Task<ListShipmentsResponseBody> ListShipments(HttpClient methodClient, DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, DateTimeOffset? modifiedAtStart, DateTimeOffset? modifiedAtEnd, ShipmentStatus? shipmentStatus, ShipmentsSortBy? sortBy, SortDir? sortDir, string? batchId, string? tag, string? salesOrderId, int? page, int? pageSize, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListShipmentsResponseBody)</returns>
+    Task<ShipEngineResponse<ListShipmentsResponseBody>> ListShipments(HttpClient methodClient, DateTimeOffset? createdAtStart, DateTimeOffset? createdAtEnd, DateTimeOffset? modifiedAtStart, DateTimeOffset? modifiedAtEnd, ShipmentStatus? shipmentStatus, ShipmentsSortBy? sortBy, SortDir? sortDir, string? batchId, string? tag, string? salesOrderId, int? page, int? pageSize, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Parse shipping info The shipment-recognition API makes it easy for you to extract shipping data from unstructured text, including people&#39;s names, addresses, package weights and dimensions, insurance and delivery requirements, and more.  Data often enters your system as unstructured text (for example: emails, SMS messages, support tickets, or other documents). ShipEngine&#39;s shipment-recognition API helps you extract meaningful, structured data from this unstructured text. The parsed shipment data is returned in the same structure that&#39;s used for other ShipEngine APIs, so you can easily use the parsed data to create a shipping label.  &gt; **Note:** Shipment recognition is currently supported for the United States, Canada, Australia, New Zealand, the United Kingdom, and Ireland. 
@@ -181,8 +181,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="parseShipmentRequestBody">The only required field is &#x60;text&#x60;, which is the text to be parsed. You can optionally also provide a &#x60;shipment&#x60; containing any already-known values. For example, you probably already know the &#x60;ship_from&#x60; address, and you may also already know what carrier and service you want to use. </param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ParseShipmentResponseBody)</returns>
-    Task<ParseShipmentResponseBody> ParseShipment(ParseShipmentRequestBody parseShipmentRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ParseShipmentResponseBody)</returns>
+    Task<ShipEngineResponse<ParseShipmentResponseBody>> ParseShipment(ParseShipmentRequestBody parseShipmentRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Parse shipping info The shipment-recognition API makes it easy for you to extract shipping data from unstructured text, including people&#39;s names, addresses, package weights and dimensions, insurance and delivery requirements, and more.  Data often enters your system as unstructured text (for example: emails, SMS messages, support tickets, or other documents). ShipEngine&#39;s shipment-recognition API helps you extract meaningful, structured data from this unstructured text. The parsed shipment data is returned in the same structure that&#39;s used for other ShipEngine APIs, so you can easily use the parsed data to create a shipping label.  &gt; **Note:** Shipment recognition is currently supported for the United States, Canada, Australia, New Zealand, the United Kingdom, and Ireland. 
@@ -192,8 +192,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="parseShipmentRequestBody">The only required field is &#x60;text&#x60;, which is the text to be parsed. You can optionally also provide a &#x60;shipment&#x60; containing any already-known values. For example, you probably already know the &#x60;ship_from&#x60; address, and you may also already know what carrier and service you want to use. </param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ParseShipmentResponseBody)</returns>
-    Task<ParseShipmentResponseBody> ParseShipment(HttpClient methodClient, ParseShipmentRequestBody parseShipmentRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ParseShipmentResponseBody)</returns>
+    Task<ShipEngineResponse<ParseShipmentResponseBody>> ParseShipment(HttpClient methodClient, ParseShipmentRequestBody parseShipmentRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Shipment Tags Get Shipment tags based on its ID
@@ -202,8 +202,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (TagShipmentResponseBody)</returns>
-    Task<TagShipmentResponseBody> ShipmentsListTags(string shipmentId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (TagShipmentResponseBody)</returns>
+    Task<ShipEngineResponse<TagShipmentResponseBody>> ShipmentsListTags(string shipmentId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Shipment Tags Get Shipment tags based on its ID
@@ -213,8 +213,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (TagShipmentResponseBody)</returns>
-    Task<TagShipmentResponseBody> ShipmentsListTags(HttpClient methodClient, string shipmentId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (TagShipmentResponseBody)</returns>
+    Task<ShipEngineResponse<TagShipmentResponseBody>> ShipmentsListTags(HttpClient methodClient, string shipmentId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Shipments Tags Update Shipments Tags
@@ -223,8 +223,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="updateShipmentsTagsRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse</returns>
-    Task<Object> ShipmentsUpdateTags(UpdateShipmentsTagsRequestBody updateShipmentsTagsRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse</returns>
+    Task<ShipEngineResponse<Object>> ShipmentsUpdateTags(UpdateShipmentsTagsRequestBody updateShipmentsTagsRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Shipments Tags Update Shipments Tags
@@ -234,8 +234,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="updateShipmentsTagsRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse</returns>
-    Task<Object> ShipmentsUpdateTags(HttpClient methodClient, UpdateShipmentsTagsRequestBody updateShipmentsTagsRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse</returns>
+    Task<ShipEngineResponse<Object>> ShipmentsUpdateTags(HttpClient methodClient, UpdateShipmentsTagsRequestBody updateShipmentsTagsRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Add Tag to Shipment Add a tag to the shipment object
@@ -245,8 +245,8 @@ public partial interface IShipEngine
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (TagShipmentResponseBody)</returns>
-    Task<TagShipmentResponseBody> TagShipment(string shipmentId, string tagName, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (TagShipmentResponseBody)</returns>
+    Task<ShipEngineResponse<TagShipmentResponseBody>> TagShipment(string shipmentId, string tagName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Add Tag to Shipment Add a tag to the shipment object
@@ -257,8 +257,8 @@ public partial interface IShipEngine
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (TagShipmentResponseBody)</returns>
-    Task<TagShipmentResponseBody> TagShipment(HttpClient methodClient, string shipmentId, string tagName, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (TagShipmentResponseBody)</returns>
+    Task<ShipEngineResponse<TagShipmentResponseBody>> TagShipment(HttpClient methodClient, string shipmentId, string tagName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Remove Tag from Shipment Remove an existing tag from the Shipment object
@@ -268,8 +268,8 @@ public partial interface IShipEngine
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UntagShipment(string shipmentId, string tagName, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UntagShipment(string shipmentId, string tagName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Remove Tag from Shipment Remove an existing tag from the Shipment object
@@ -280,8 +280,8 @@ public partial interface IShipEngine
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UntagShipment(HttpClient methodClient, string shipmentId, string tagName, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UntagShipment(HttpClient methodClient, string shipmentId, string tagName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Shipment By ID Update a shipment object based on its ID
@@ -291,8 +291,8 @@ public partial interface IShipEngine
     /// <param name="updateShipmentRequestBody"></param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (UpdateShipmentResponseBody)</returns>
-    Task<UpdateShipmentResponseBody> UpdateShipment(UpdateShipmentRequestBody updateShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (UpdateShipmentResponseBody)</returns>
+    Task<ShipEngineResponse<UpdateShipmentResponseBody>> UpdateShipment(UpdateShipmentRequestBody updateShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Shipment By ID Update a shipment object based on its ID
@@ -303,8 +303,8 @@ public partial interface IShipEngine
     /// <param name="updateShipmentRequestBody"></param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (UpdateShipmentResponseBody)</returns>
-    Task<UpdateShipmentResponseBody> UpdateShipment(HttpClient methodClient, UpdateShipmentRequestBody updateShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (UpdateShipmentResponseBody)</returns>
+    Task<ShipEngineResponse<UpdateShipmentResponseBody>> UpdateShipment(HttpClient methodClient, UpdateShipmentRequestBody updateShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default);
 
 }
 
@@ -320,8 +320,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> CancelShipments(string shipmentId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> CancelShipments(string shipmentId, CancellationToken cancellationToken = default)
     {
         return CancelShipments(_client, shipmentId, cancellationToken);
     }
@@ -334,8 +334,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> CancelShipments(HttpClient methodClient, string shipmentId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> CancelShipments(HttpClient methodClient, string shipmentId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'shipmentId' is set
         if (shipmentId == null)
@@ -350,9 +350,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.CancelShipments";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -362,8 +363,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createShipmentsRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateShipmentsResponseBody)</returns>
-    public Task<CreateShipmentsResponseBody> CreateShipments(CreateShipmentsRequestBody createShipmentsRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateShipmentsResponseBody)</returns>
+    public Task<ShipEngineResponse<CreateShipmentsResponseBody>> CreateShipments(CreateShipmentsRequestBody createShipmentsRequestBody, CancellationToken cancellationToken = default)
     {
         return CreateShipments(_client, createShipmentsRequestBody, cancellationToken);
     }
@@ -376,8 +377,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createShipmentsRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateShipmentsResponseBody)</returns>
-    public async Task<CreateShipmentsResponseBody> CreateShipments(HttpClient methodClient, CreateShipmentsRequestBody createShipmentsRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateShipmentsResponseBody)</returns>
+    public async Task<ShipEngineResponse<CreateShipmentsResponseBody>> CreateShipments(HttpClient methodClient, CreateShipmentsRequestBody createShipmentsRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'createShipmentsRequestBody' is set
         if (createShipmentsRequestBody == null)
@@ -392,9 +393,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.CreateShipments";
 
-        var result = await SendHttpRequestAsync<CreateShipmentsResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<CreateShipmentsResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<CreateShipmentsResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -404,8 +406,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="externalShipmentId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetShipmentByExternalIdResponseBody)</returns>
-    public Task<GetShipmentByExternalIdResponseBody> GetShipmentByExternalId(string externalShipmentId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetShipmentByExternalIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetShipmentByExternalIdResponseBody>> GetShipmentByExternalId(string externalShipmentId, CancellationToken cancellationToken = default)
     {
         return GetShipmentByExternalId(_client, externalShipmentId, cancellationToken);
     }
@@ -418,8 +420,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="externalShipmentId"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetShipmentByExternalIdResponseBody)</returns>
-    public async Task<GetShipmentByExternalIdResponseBody> GetShipmentByExternalId(HttpClient methodClient, string externalShipmentId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetShipmentByExternalIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetShipmentByExternalIdResponseBody>> GetShipmentByExternalId(HttpClient methodClient, string externalShipmentId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'externalShipmentId' is set
         if (externalShipmentId == null)
@@ -434,9 +436,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.GetShipmentByExternalId";
 
-        var result = await SendHttpRequestAsync<GetShipmentByExternalIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetShipmentByExternalIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetShipmentByExternalIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -446,8 +449,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetShipmentByIdResponseBody)</returns>
-    public Task<GetShipmentByIdResponseBody> GetShipmentById(string shipmentId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetShipmentByIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetShipmentByIdResponseBody>> GetShipmentById(string shipmentId, CancellationToken cancellationToken = default)
     {
         return GetShipmentById(_client, shipmentId, cancellationToken);
     }
@@ -460,8 +463,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetShipmentByIdResponseBody)</returns>
-    public async Task<GetShipmentByIdResponseBody> GetShipmentById(HttpClient methodClient, string shipmentId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetShipmentByIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetShipmentByIdResponseBody>> GetShipmentById(HttpClient methodClient, string shipmentId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'shipmentId' is set
         if (shipmentId == null)
@@ -476,9 +479,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.GetShipmentById";
 
-        var result = await SendHttpRequestAsync<GetShipmentByIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetShipmentByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetShipmentByIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -489,8 +493,8 @@ public partial class ShipEngine
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="createdAtStart">Used to create a filter for when a resource was created (ex. A shipment that was created after a certain time) (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListShipmentRatesResponseBody)</returns>
-    public Task<ListShipmentRatesResponseBody> ListShipmentRates(string shipmentId, DateTimeOffset? createdAtStart = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListShipmentRatesResponseBody)</returns>
+    public Task<ShipEngineResponse<ListShipmentRatesResponseBody>> ListShipmentRates(string shipmentId, DateTimeOffset? createdAtStart = default, CancellationToken cancellationToken = default)
     {
         return ListShipmentRates(_client, shipmentId, createdAtStart, cancellationToken);
     }
@@ -504,8 +508,8 @@ public partial class ShipEngine
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="createdAtStart">Used to create a filter for when a resource was created (ex. A shipment that was created after a certain time) (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListShipmentRatesResponseBody)</returns>
-    public async Task<ListShipmentRatesResponseBody> ListShipmentRates(HttpClient methodClient, string shipmentId, DateTimeOffset? createdAtStart = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListShipmentRatesResponseBody)</returns>
+    public async Task<ShipEngineResponse<ListShipmentRatesResponseBody>> ListShipmentRates(HttpClient methodClient, string shipmentId, DateTimeOffset? createdAtStart = default, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'shipmentId' is set
         if (shipmentId == null)
@@ -524,9 +528,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.ListShipmentRates";
 
-        var result = await SendHttpRequestAsync<ListShipmentRatesResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ListShipmentRatesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ListShipmentRatesResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -547,8 +552,8 @@ public partial class ShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListShipmentsResponseBody)</returns>
-    public Task<ListShipmentsResponseBody> ListShipments(DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, DateTimeOffset? modifiedAtStart = default, DateTimeOffset? modifiedAtEnd = default, ShipmentStatus? shipmentStatus = default, ShipmentsSortBy? sortBy = default, SortDir? sortDir = default, string? batchId = default, string? tag = default, string? salesOrderId = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListShipmentsResponseBody)</returns>
+    public Task<ShipEngineResponse<ListShipmentsResponseBody>> ListShipments(DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, DateTimeOffset? modifiedAtStart = default, DateTimeOffset? modifiedAtEnd = default, ShipmentStatus? shipmentStatus = default, ShipmentsSortBy? sortBy = default, SortDir? sortDir = default, string? batchId = default, string? tag = default, string? salesOrderId = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
     {
         return ListShipments(_client, createdAtStart, createdAtEnd, modifiedAtStart, modifiedAtEnd, shipmentStatus, sortBy, sortDir, batchId, tag, salesOrderId, page, pageSize, cancellationToken);
     }
@@ -572,8 +577,8 @@ public partial class ShipEngine
     /// <param name="page">Return a specific page of results. Defaults to the first page. If set to a number that&#39;s greater than the number of pages of results, an empty page is returned.  (optional, default to 1)</param>
     /// <param name="pageSize">The number of results to return per response. (optional, default to 25)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListShipmentsResponseBody)</returns>
-    public async Task<ListShipmentsResponseBody> ListShipments(HttpClient methodClient, DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, DateTimeOffset? modifiedAtStart = default, DateTimeOffset? modifiedAtEnd = default, ShipmentStatus? shipmentStatus = default, ShipmentsSortBy? sortBy = default, SortDir? sortDir = default, string? batchId = default, string? tag = default, string? salesOrderId = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListShipmentsResponseBody)</returns>
+    public async Task<ShipEngineResponse<ListShipmentsResponseBody>> ListShipments(HttpClient methodClient, DateTimeOffset? createdAtStart = default, DateTimeOffset? createdAtEnd = default, DateTimeOffset? modifiedAtStart = default, DateTimeOffset? modifiedAtEnd = default, ShipmentStatus? shipmentStatus = default, ShipmentsSortBy? sortBy = default, SortDir? sortDir = default, string? batchId = default, string? tag = default, string? salesOrderId = default, int? page = default, int? pageSize = default, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/shipments");
@@ -629,9 +634,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.ListShipments";
 
-        var result = await SendHttpRequestAsync<ListShipmentsResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ListShipmentsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ListShipmentsResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -641,8 +647,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="parseShipmentRequestBody">The only required field is &#x60;text&#x60;, which is the text to be parsed. You can optionally also provide a &#x60;shipment&#x60; containing any already-known values. For example, you probably already know the &#x60;ship_from&#x60; address, and you may also already know what carrier and service you want to use. </param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ParseShipmentResponseBody)</returns>
-    public Task<ParseShipmentResponseBody> ParseShipment(ParseShipmentRequestBody parseShipmentRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ParseShipmentResponseBody)</returns>
+    public Task<ShipEngineResponse<ParseShipmentResponseBody>> ParseShipment(ParseShipmentRequestBody parseShipmentRequestBody, CancellationToken cancellationToken = default)
     {
         return ParseShipment(_client, parseShipmentRequestBody, cancellationToken);
     }
@@ -655,8 +661,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="parseShipmentRequestBody">The only required field is &#x60;text&#x60;, which is the text to be parsed. You can optionally also provide a &#x60;shipment&#x60; containing any already-known values. For example, you probably already know the &#x60;ship_from&#x60; address, and you may also already know what carrier and service you want to use. </param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ParseShipmentResponseBody)</returns>
-    public async Task<ParseShipmentResponseBody> ParseShipment(HttpClient methodClient, ParseShipmentRequestBody parseShipmentRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ParseShipmentResponseBody)</returns>
+    public async Task<ShipEngineResponse<ParseShipmentResponseBody>> ParseShipment(HttpClient methodClient, ParseShipmentRequestBody parseShipmentRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'parseShipmentRequestBody' is set
         if (parseShipmentRequestBody == null)
@@ -671,9 +677,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.ParseShipment";
 
-        var result = await SendHttpRequestAsync<ParseShipmentResponseBody>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ParseShipmentResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ParseShipmentResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -683,8 +690,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (TagShipmentResponseBody)</returns>
-    public Task<TagShipmentResponseBody> ShipmentsListTags(string shipmentId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (TagShipmentResponseBody)</returns>
+    public Task<ShipEngineResponse<TagShipmentResponseBody>> ShipmentsListTags(string shipmentId, CancellationToken cancellationToken = default)
     {
         return ShipmentsListTags(_client, shipmentId, cancellationToken);
     }
@@ -697,8 +704,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (TagShipmentResponseBody)</returns>
-    public async Task<TagShipmentResponseBody> ShipmentsListTags(HttpClient methodClient, string shipmentId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (TagShipmentResponseBody)</returns>
+    public async Task<ShipEngineResponse<TagShipmentResponseBody>> ShipmentsListTags(HttpClient methodClient, string shipmentId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'shipmentId' is set
         if (shipmentId == null)
@@ -713,9 +720,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.ShipmentsListTags";
 
-        var result = await SendHttpRequestAsync<TagShipmentResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<TagShipmentResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<TagShipmentResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -725,8 +733,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="updateShipmentsTagsRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse</returns>
-    public Task<Object> ShipmentsUpdateTags(UpdateShipmentsTagsRequestBody updateShipmentsTagsRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse</returns>
+    public Task<ShipEngineResponse<Object>> ShipmentsUpdateTags(UpdateShipmentsTagsRequestBody updateShipmentsTagsRequestBody, CancellationToken cancellationToken = default)
     {
         return ShipmentsUpdateTags(_client, updateShipmentsTagsRequestBody, cancellationToken);
     }
@@ -739,8 +747,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="updateShipmentsTagsRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse</returns>
-    public async Task<Object> ShipmentsUpdateTags(HttpClient methodClient, UpdateShipmentsTagsRequestBody updateShipmentsTagsRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse</returns>
+    public async Task<ShipEngineResponse<Object>> ShipmentsUpdateTags(HttpClient methodClient, UpdateShipmentsTagsRequestBody updateShipmentsTagsRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'updateShipmentsTagsRequestBody' is set
         if (updateShipmentsTagsRequestBody == null)
@@ -755,9 +763,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.ShipmentsUpdateTags";
 
-        var result = await SendHttpRequestAsync<Object>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<Object>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<Object>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -768,8 +777,8 @@ public partial class ShipEngine
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (TagShipmentResponseBody)</returns>
-    public Task<TagShipmentResponseBody> TagShipment(string shipmentId, string tagName, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (TagShipmentResponseBody)</returns>
+    public Task<ShipEngineResponse<TagShipmentResponseBody>> TagShipment(string shipmentId, string tagName, CancellationToken cancellationToken = default)
     {
         return TagShipment(_client, shipmentId, tagName, cancellationToken);
     }
@@ -783,8 +792,8 @@ public partial class ShipEngine
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (TagShipmentResponseBody)</returns>
-    public async Task<TagShipmentResponseBody> TagShipment(HttpClient methodClient, string shipmentId, string tagName, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (TagShipmentResponseBody)</returns>
+    public async Task<ShipEngineResponse<TagShipmentResponseBody>> TagShipment(HttpClient methodClient, string shipmentId, string tagName, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'shipmentId' is set
         if (shipmentId == null)
@@ -806,9 +815,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.TagShipment";
 
-        var result = await SendHttpRequestAsync<TagShipmentResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<TagShipmentResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<TagShipmentResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -819,8 +829,8 @@ public partial class ShipEngine
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> UntagShipment(string shipmentId, string tagName, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> UntagShipment(string shipmentId, string tagName, CancellationToken cancellationToken = default)
     {
         return UntagShipment(_client, shipmentId, tagName, cancellationToken);
     }
@@ -834,8 +844,8 @@ public partial class ShipEngine
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> UntagShipment(HttpClient methodClient, string shipmentId, string tagName, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> UntagShipment(HttpClient methodClient, string shipmentId, string tagName, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'shipmentId' is set
         if (shipmentId == null)
@@ -857,9 +867,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.UntagShipment";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Delete, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -870,8 +881,8 @@ public partial class ShipEngine
     /// <param name="updateShipmentRequestBody"></param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (UpdateShipmentResponseBody)</returns>
-    public Task<UpdateShipmentResponseBody> UpdateShipment(UpdateShipmentRequestBody updateShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (UpdateShipmentResponseBody)</returns>
+    public Task<ShipEngineResponse<UpdateShipmentResponseBody>> UpdateShipment(UpdateShipmentRequestBody updateShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default)
     {
         return UpdateShipment(_client, updateShipmentRequestBody, shipmentId, cancellationToken);
     }
@@ -885,8 +896,8 @@ public partial class ShipEngine
     /// <param name="updateShipmentRequestBody"></param>
     /// <param name="shipmentId">Shipment ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (UpdateShipmentResponseBody)</returns>
-    public async Task<UpdateShipmentResponseBody> UpdateShipment(HttpClient methodClient, UpdateShipmentRequestBody updateShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (UpdateShipmentResponseBody)</returns>
+    public async Task<ShipEngineResponse<UpdateShipmentResponseBody>> UpdateShipment(HttpClient methodClient, UpdateShipmentRequestBody updateShipmentRequestBody, string shipmentId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'updateShipmentRequestBody' is set
         if (updateShipmentRequestBody == null)
@@ -908,9 +919,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "ShipmentsApi.UpdateShipment";
 
-        var result = await SendHttpRequestAsync<UpdateShipmentResponseBody>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<UpdateShipmentResponseBody>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<UpdateShipmentResponseBody>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/TagsApi.cs
+++ b/ShipEngineSDK/Api/TagsApi.cs
@@ -152,10 +152,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TagsApi.CreateTag";
 
-        var (data, response) = await GetHttpResponse<CreateTagResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<CreateTagResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<CreateTagResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -195,10 +192,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TagsApi.DeleteTag";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -229,10 +223,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TagsApi.ListTags";
 
-        var (data, response) = await GetHttpResponse<ListTagsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ListTagsResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ListTagsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -281,10 +272,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TagsApi.RenameTag";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/TagsApi.cs
+++ b/ShipEngineSDK/Api/TagsApi.cs
@@ -31,8 +31,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateTagResponseBody)</returns>
-    Task<CreateTagResponseBody> CreateTag(string tagName, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateTagResponseBody)</returns>
+    Task<ShipEngineResponse<CreateTagResponseBody>> CreateTag(string tagName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create a New Tag Create a new Tag for customizing how you track your shipments
@@ -42,8 +42,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateTagResponseBody)</returns>
-    Task<CreateTagResponseBody> CreateTag(HttpClient methodClient, string tagName, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateTagResponseBody)</returns>
+    Task<ShipEngineResponse<CreateTagResponseBody>> CreateTag(HttpClient methodClient, string tagName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete Tag Delete a tag that is no longer needed
@@ -52,8 +52,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DeleteTag(string tagName, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DeleteTag(string tagName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete Tag Delete a tag that is no longer needed
@@ -63,8 +63,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DeleteTag(HttpClient methodClient, string tagName, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DeleteTag(HttpClient methodClient, string tagName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Tags Get a list of all tags associated with an account.
@@ -72,8 +72,8 @@ public partial interface IShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListTagsResponseBody)</returns>
-    Task<ListTagsResponseBody> ListTags(CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListTagsResponseBody)</returns>
+    Task<ShipEngineResponse<ListTagsResponseBody>> ListTags(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Tags Get a list of all tags associated with an account.
@@ -82,8 +82,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListTagsResponseBody)</returns>
-    Task<ListTagsResponseBody> ListTags(HttpClient methodClient, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListTagsResponseBody)</returns>
+    Task<ShipEngineResponse<ListTagsResponseBody>> ListTags(HttpClient methodClient, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Tag Name Change a tag name while still keeping the relevant shipments attached to it
@@ -93,8 +93,8 @@ public partial interface IShipEngine
     /// <param name="tagName"></param>
     /// <param name="newTagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> RenameTag(string tagName, string newTagName, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> RenameTag(string tagName, string newTagName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Tag Name Change a tag name while still keeping the relevant shipments attached to it
@@ -105,8 +105,8 @@ public partial interface IShipEngine
     /// <param name="tagName"></param>
     /// <param name="newTagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> RenameTag(HttpClient methodClient, string tagName, string newTagName, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> RenameTag(HttpClient methodClient, string tagName, string newTagName, CancellationToken cancellationToken = default);
 
 }
 
@@ -122,8 +122,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateTagResponseBody)</returns>
-    public Task<CreateTagResponseBody> CreateTag(string tagName, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateTagResponseBody)</returns>
+    public Task<ShipEngineResponse<CreateTagResponseBody>> CreateTag(string tagName, CancellationToken cancellationToken = default)
     {
         return CreateTag(_client, tagName, cancellationToken);
     }
@@ -136,8 +136,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateTagResponseBody)</returns>
-    public async Task<CreateTagResponseBody> CreateTag(HttpClient methodClient, string tagName, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateTagResponseBody)</returns>
+    public async Task<ShipEngineResponse<CreateTagResponseBody>> CreateTag(HttpClient methodClient, string tagName, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'tagName' is set
         if (tagName == null)
@@ -152,9 +152,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TagsApi.CreateTag";
 
-        var result = await SendHttpRequestAsync<CreateTagResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<CreateTagResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<CreateTagResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -164,8 +165,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> DeleteTag(string tagName, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> DeleteTag(string tagName, CancellationToken cancellationToken = default)
     {
         return DeleteTag(_client, tagName, cancellationToken);
     }
@@ -178,8 +179,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="tagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> DeleteTag(HttpClient methodClient, string tagName, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> DeleteTag(HttpClient methodClient, string tagName, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'tagName' is set
         if (tagName == null)
@@ -194,9 +195,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TagsApi.DeleteTag";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Delete, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -205,8 +207,8 @@ public partial class ShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListTagsResponseBody)</returns>
-    public Task<ListTagsResponseBody> ListTags(CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListTagsResponseBody)</returns>
+    public Task<ShipEngineResponse<ListTagsResponseBody>> ListTags(CancellationToken cancellationToken = default)
     {
         return ListTags(_client, cancellationToken);
     }
@@ -218,8 +220,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListTagsResponseBody)</returns>
-    public async Task<ListTagsResponseBody> ListTags(HttpClient methodClient, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListTagsResponseBody)</returns>
+    public async Task<ShipEngineResponse<ListTagsResponseBody>> ListTags(HttpClient methodClient, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/tags");
@@ -227,9 +229,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TagsApi.ListTags";
 
-        var result = await SendHttpRequestAsync<ListTagsResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ListTagsResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ListTagsResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -240,8 +243,8 @@ public partial class ShipEngine
     /// <param name="tagName"></param>
     /// <param name="newTagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> RenameTag(string tagName, string newTagName, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> RenameTag(string tagName, string newTagName, CancellationToken cancellationToken = default)
     {
         return RenameTag(_client, tagName, newTagName, cancellationToken);
     }
@@ -255,8 +258,8 @@ public partial class ShipEngine
     /// <param name="tagName"></param>
     /// <param name="newTagName"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> RenameTag(HttpClient methodClient, string tagName, string newTagName, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> RenameTag(HttpClient methodClient, string tagName, string newTagName, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'tagName' is set
         if (tagName == null)
@@ -278,9 +281,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TagsApi.RenameTag";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/TokensApi.cs
+++ b/ShipEngineSDK/Api/TokensApi.cs
@@ -86,10 +86,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TokensApi.TokensGetEphemeralToken";
 
-        var (data, response) = await GetHttpResponse<TokensGetEphemeralTokenResponseBodyYaml>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<TokensGetEphemeralTokenResponseBodyYaml>(data, response.StatusCode, headers);
+        return await GetHttpResponse<TokensGetEphemeralTokenResponseBodyYaml>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/TokensApi.cs
+++ b/ShipEngineSDK/Api/TokensApi.cs
@@ -31,8 +31,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="redirect">Include a redirect url to the application formatted with the ephemeral token. (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (TokensGetEphemeralTokenResponseBodyYaml)</returns>
-    Task<TokensGetEphemeralTokenResponseBodyYaml> TokensGetEphemeralToken(Redirect? redirect, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (TokensGetEphemeralTokenResponseBodyYaml)</returns>
+    Task<ShipEngineResponse<TokensGetEphemeralTokenResponseBodyYaml>> TokensGetEphemeralToken(Redirect? redirect, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Ephemeral Token This endpoint returns a token that can be passed to an application for authorized access.  The lifetime of this token is 10 seconds.
@@ -42,8 +42,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="redirect">Include a redirect url to the application formatted with the ephemeral token. (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (TokensGetEphemeralTokenResponseBodyYaml)</returns>
-    Task<TokensGetEphemeralTokenResponseBodyYaml> TokensGetEphemeralToken(HttpClient methodClient, Redirect? redirect, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (TokensGetEphemeralTokenResponseBodyYaml)</returns>
+    Task<ShipEngineResponse<TokensGetEphemeralTokenResponseBodyYaml>> TokensGetEphemeralToken(HttpClient methodClient, Redirect? redirect, CancellationToken cancellationToken = default);
 
 }
 
@@ -59,8 +59,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="redirect">Include a redirect url to the application formatted with the ephemeral token. (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (TokensGetEphemeralTokenResponseBodyYaml)</returns>
-    public Task<TokensGetEphemeralTokenResponseBodyYaml> TokensGetEphemeralToken(Redirect? redirect = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (TokensGetEphemeralTokenResponseBodyYaml)</returns>
+    public Task<ShipEngineResponse<TokensGetEphemeralTokenResponseBodyYaml>> TokensGetEphemeralToken(Redirect? redirect = default, CancellationToken cancellationToken = default)
     {
         return TokensGetEphemeralToken(_client, redirect, cancellationToken);
     }
@@ -73,8 +73,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="redirect">Include a redirect url to the application formatted with the ephemeral token. (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (TokensGetEphemeralTokenResponseBodyYaml)</returns>
-    public async Task<TokensGetEphemeralTokenResponseBodyYaml> TokensGetEphemeralToken(HttpClient methodClient, Redirect? redirect = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (TokensGetEphemeralTokenResponseBodyYaml)</returns>
+    public async Task<ShipEngineResponse<TokensGetEphemeralTokenResponseBodyYaml>> TokensGetEphemeralToken(HttpClient methodClient, Redirect? redirect = default, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/tokens/ephemeral");
@@ -86,9 +86,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TokensApi.TokensGetEphemeralToken";
 
-        var result = await SendHttpRequestAsync<TokensGetEphemeralTokenResponseBodyYaml>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<TokensGetEphemeralTokenResponseBodyYaml>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<TokensGetEphemeralTokenResponseBodyYaml>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/TrackingApi.cs
+++ b/ShipEngineSDK/Api/TrackingApi.cs
@@ -32,8 +32,8 @@ public partial interface IShipEngine
     /// <param name="carrierCode">A [shipping carrier](https://www.shipengine.com/docs/carriers/setup/), such as &#x60;fedex&#x60;, &#x60;dhl_express&#x60;, &#x60;stamps_com&#x60;, etc.  (optional)</param>
     /// <param name="trackingNumber">The tracking number associated with a shipment (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetTrackingLogResponseBody)</returns>
-    Task<GetTrackingLogResponseBody> GetTrackingLog(string? carrierCode, string? trackingNumber, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetTrackingLogResponseBody)</returns>
+    Task<ShipEngineResponse<GetTrackingLogResponseBody>> GetTrackingLog(string? carrierCode, string? trackingNumber, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Tracking Information Retrieve package tracking information
@@ -44,8 +44,8 @@ public partial interface IShipEngine
     /// <param name="carrierCode">A [shipping carrier](https://www.shipengine.com/docs/carriers/setup/), such as &#x60;fedex&#x60;, &#x60;dhl_express&#x60;, &#x60;stamps_com&#x60;, etc.  (optional)</param>
     /// <param name="trackingNumber">The tracking number associated with a shipment (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetTrackingLogResponseBody)</returns>
-    Task<GetTrackingLogResponseBody> GetTrackingLog(HttpClient methodClient, string? carrierCode, string? trackingNumber, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetTrackingLogResponseBody)</returns>
+    Task<ShipEngineResponse<GetTrackingLogResponseBody>> GetTrackingLog(HttpClient methodClient, string? carrierCode, string? trackingNumber, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Start Tracking a Package Allows you to subscribe to tracking updates for a package. You specify the carrier_code and tracking_number of the package, and receive notifications via webhooks whenever the shipping status changes. 
@@ -55,8 +55,8 @@ public partial interface IShipEngine
     /// <param name="carrierCode">A [shipping carrier](https://www.shipengine.com/docs/carriers/setup/), such as &#x60;fedex&#x60;, &#x60;dhl_express&#x60;, &#x60;stamps_com&#x60;, etc.  (optional)</param>
     /// <param name="trackingNumber">The tracking number associated with a shipment (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> StartTracking(string? carrierCode, string? trackingNumber, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> StartTracking(string? carrierCode, string? trackingNumber, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Start Tracking a Package Allows you to subscribe to tracking updates for a package. You specify the carrier_code and tracking_number of the package, and receive notifications via webhooks whenever the shipping status changes. 
@@ -67,8 +67,8 @@ public partial interface IShipEngine
     /// <param name="carrierCode">A [shipping carrier](https://www.shipengine.com/docs/carriers/setup/), such as &#x60;fedex&#x60;, &#x60;dhl_express&#x60;, &#x60;stamps_com&#x60;, etc.  (optional)</param>
     /// <param name="trackingNumber">The tracking number associated with a shipment (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> StartTracking(HttpClient methodClient, string? carrierCode, string? trackingNumber, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> StartTracking(HttpClient methodClient, string? carrierCode, string? trackingNumber, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Stop Tracking a Package Unsubscribe from tracking updates for a package.
@@ -78,8 +78,8 @@ public partial interface IShipEngine
     /// <param name="carrierCode">A [shipping carrier](https://www.shipengine.com/docs/carriers/setup/), such as &#x60;fedex&#x60;, &#x60;dhl_express&#x60;, &#x60;stamps_com&#x60;, etc.  (optional)</param>
     /// <param name="trackingNumber">The tracking number associated with a shipment (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> StopTracking(string? carrierCode, string? trackingNumber, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> StopTracking(string? carrierCode, string? trackingNumber, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Stop Tracking a Package Unsubscribe from tracking updates for a package.
@@ -90,8 +90,8 @@ public partial interface IShipEngine
     /// <param name="carrierCode">A [shipping carrier](https://www.shipengine.com/docs/carriers/setup/), such as &#x60;fedex&#x60;, &#x60;dhl_express&#x60;, &#x60;stamps_com&#x60;, etc.  (optional)</param>
     /// <param name="trackingNumber">The tracking number associated with a shipment (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> StopTracking(HttpClient methodClient, string? carrierCode, string? trackingNumber, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> StopTracking(HttpClient methodClient, string? carrierCode, string? trackingNumber, CancellationToken cancellationToken = default);
 
 }
 
@@ -108,8 +108,8 @@ public partial class ShipEngine
     /// <param name="carrierCode">A [shipping carrier](https://www.shipengine.com/docs/carriers/setup/), such as &#x60;fedex&#x60;, &#x60;dhl_express&#x60;, &#x60;stamps_com&#x60;, etc.  (optional)</param>
     /// <param name="trackingNumber">The tracking number associated with a shipment (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetTrackingLogResponseBody)</returns>
-    public Task<GetTrackingLogResponseBody> GetTrackingLog(string? carrierCode = default, string? trackingNumber = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetTrackingLogResponseBody)</returns>
+    public Task<ShipEngineResponse<GetTrackingLogResponseBody>> GetTrackingLog(string? carrierCode = default, string? trackingNumber = default, CancellationToken cancellationToken = default)
     {
         return GetTrackingLog(_client, carrierCode, trackingNumber, cancellationToken);
     }
@@ -123,8 +123,8 @@ public partial class ShipEngine
     /// <param name="carrierCode">A [shipping carrier](https://www.shipengine.com/docs/carriers/setup/), such as &#x60;fedex&#x60;, &#x60;dhl_express&#x60;, &#x60;stamps_com&#x60;, etc.  (optional)</param>
     /// <param name="trackingNumber">The tracking number associated with a shipment (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetTrackingLogResponseBody)</returns>
-    public async Task<GetTrackingLogResponseBody> GetTrackingLog(HttpClient methodClient, string? carrierCode = default, string? trackingNumber = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetTrackingLogResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetTrackingLogResponseBody>> GetTrackingLog(HttpClient methodClient, string? carrierCode = default, string? trackingNumber = default, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/tracking");
@@ -140,9 +140,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TrackingApi.GetTrackingLog";
 
-        var result = await SendHttpRequestAsync<GetTrackingLogResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetTrackingLogResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetTrackingLogResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -153,8 +154,8 @@ public partial class ShipEngine
     /// <param name="carrierCode">A [shipping carrier](https://www.shipengine.com/docs/carriers/setup/), such as &#x60;fedex&#x60;, &#x60;dhl_express&#x60;, &#x60;stamps_com&#x60;, etc.  (optional)</param>
     /// <param name="trackingNumber">The tracking number associated with a shipment (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> StartTracking(string? carrierCode = default, string? trackingNumber = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> StartTracking(string? carrierCode = default, string? trackingNumber = default, CancellationToken cancellationToken = default)
     {
         return StartTracking(_client, carrierCode, trackingNumber, cancellationToken);
     }
@@ -168,8 +169,8 @@ public partial class ShipEngine
     /// <param name="carrierCode">A [shipping carrier](https://www.shipengine.com/docs/carriers/setup/), such as &#x60;fedex&#x60;, &#x60;dhl_express&#x60;, &#x60;stamps_com&#x60;, etc.  (optional)</param>
     /// <param name="trackingNumber">The tracking number associated with a shipment (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> StartTracking(HttpClient methodClient, string? carrierCode = default, string? trackingNumber = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> StartTracking(HttpClient methodClient, string? carrierCode = default, string? trackingNumber = default, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/tracking/start");
@@ -185,9 +186,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TrackingApi.StartTracking";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -198,8 +200,8 @@ public partial class ShipEngine
     /// <param name="carrierCode">A [shipping carrier](https://www.shipengine.com/docs/carriers/setup/), such as &#x60;fedex&#x60;, &#x60;dhl_express&#x60;, &#x60;stamps_com&#x60;, etc.  (optional)</param>
     /// <param name="trackingNumber">The tracking number associated with a shipment (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> StopTracking(string? carrierCode = default, string? trackingNumber = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> StopTracking(string? carrierCode = default, string? trackingNumber = default, CancellationToken cancellationToken = default)
     {
         return StopTracking(_client, carrierCode, trackingNumber, cancellationToken);
     }
@@ -213,8 +215,8 @@ public partial class ShipEngine
     /// <param name="carrierCode">A [shipping carrier](https://www.shipengine.com/docs/carriers/setup/), such as &#x60;fedex&#x60;, &#x60;dhl_express&#x60;, &#x60;stamps_com&#x60;, etc.  (optional)</param>
     /// <param name="trackingNumber">The tracking number associated with a shipment (optional)</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> StopTracking(HttpClient methodClient, string? carrierCode = default, string? trackingNumber = default, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> StopTracking(HttpClient methodClient, string? carrierCode = default, string? trackingNumber = default, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/tracking/stop");
@@ -230,9 +232,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TrackingApi.StopTracking";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/TrackingApi.cs
+++ b/ShipEngineSDK/Api/TrackingApi.cs
@@ -140,10 +140,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TrackingApi.GetTrackingLog";
 
-        var (data, response) = await GetHttpResponse<GetTrackingLogResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetTrackingLogResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetTrackingLogResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -186,10 +183,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TrackingApi.StartTracking";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -232,10 +226,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "TrackingApi.StopTracking";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/WarehousesApi.cs
+++ b/ShipEngineSDK/Api/WarehousesApi.cs
@@ -31,8 +31,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createWarehouseRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateWarehouseResponseBody)</returns>
-    Task<CreateWarehouseResponseBody> CreateWarehouse(CreateWarehouseRequestBody createWarehouseRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateWarehouseResponseBody)</returns>
+    Task<ShipEngineResponse<CreateWarehouseResponseBody>> CreateWarehouse(CreateWarehouseRequestBody createWarehouseRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create Warehouse Create a warehouse location that you can use to create shipping items by simply passing in the generated warehouse id. If the return address is not supplied in the request body then it is assumed that the origin address is the return address as well 
@@ -42,8 +42,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createWarehouseRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateWarehouseResponseBody)</returns>
-    Task<CreateWarehouseResponseBody> CreateWarehouse(HttpClient methodClient, CreateWarehouseRequestBody createWarehouseRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateWarehouseResponseBody)</returns>
+    Task<ShipEngineResponse<CreateWarehouseResponseBody>> CreateWarehouse(HttpClient methodClient, CreateWarehouseRequestBody createWarehouseRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete Warehouse By ID Delete a warehouse by ID
@@ -52,8 +52,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DeleteWarehouse(string warehouseId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DeleteWarehouse(string warehouseId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete Warehouse By ID Delete a warehouse by ID
@@ -63,8 +63,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DeleteWarehouse(HttpClient methodClient, string warehouseId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DeleteWarehouse(HttpClient methodClient, string warehouseId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Warehouse By Id Retrieve warehouse data based on the warehouse ID
@@ -73,8 +73,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetWarehouseByIdResponseBody)</returns>
-    Task<GetWarehouseByIdResponseBody> GetWarehouseById(string warehouseId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetWarehouseByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetWarehouseByIdResponseBody>> GetWarehouseById(string warehouseId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Warehouse By Id Retrieve warehouse data based on the warehouse ID
@@ -84,8 +84,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetWarehouseByIdResponseBody)</returns>
-    Task<GetWarehouseByIdResponseBody> GetWarehouseById(HttpClient methodClient, string warehouseId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetWarehouseByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetWarehouseByIdResponseBody>> GetWarehouseById(HttpClient methodClient, string warehouseId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Warehouses Retrieve a list of warehouses associated with this account.
@@ -93,8 +93,8 @@ public partial interface IShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListWarehousesResponseBody)</returns>
-    Task<ListWarehousesResponseBody> ListWarehouses(CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListWarehousesResponseBody)</returns>
+    Task<ShipEngineResponse<ListWarehousesResponseBody>> ListWarehouses(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Warehouses Retrieve a list of warehouses associated with this account.
@@ -103,8 +103,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListWarehousesResponseBody)</returns>
-    Task<ListWarehousesResponseBody> ListWarehouses(HttpClient methodClient, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (ListWarehousesResponseBody)</returns>
+    Task<ShipEngineResponse<ListWarehousesResponseBody>> ListWarehouses(HttpClient methodClient, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Warehouse By Id Update Warehouse object information
@@ -114,8 +114,8 @@ public partial interface IShipEngine
     /// <param name="updateWarehouseRequestBody"></param>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdateWarehouse(UpdateWarehouseRequestBody updateWarehouseRequestBody, string warehouseId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdateWarehouse(UpdateWarehouseRequestBody updateWarehouseRequestBody, string warehouseId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Warehouse By Id Update Warehouse object information
@@ -126,8 +126,8 @@ public partial interface IShipEngine
     /// <param name="updateWarehouseRequestBody"></param>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdateWarehouse(HttpClient methodClient, UpdateWarehouseRequestBody updateWarehouseRequestBody, string warehouseId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdateWarehouse(HttpClient methodClient, UpdateWarehouseRequestBody updateWarehouseRequestBody, string warehouseId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Warehouse Settings Update Warehouse settings object information
@@ -137,8 +137,8 @@ public partial interface IShipEngine
     /// <param name="updateWarehouseSettingsRequestBody"></param>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdateWarehouseSettings(UpdateWarehouseSettingsRequestBody updateWarehouseSettingsRequestBody, string warehouseId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdateWarehouseSettings(UpdateWarehouseSettingsRequestBody updateWarehouseSettingsRequestBody, string warehouseId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update Warehouse Settings Update Warehouse settings object information
@@ -149,8 +149,8 @@ public partial interface IShipEngine
     /// <param name="updateWarehouseSettingsRequestBody"></param>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdateWarehouseSettings(HttpClient methodClient, UpdateWarehouseSettingsRequestBody updateWarehouseSettingsRequestBody, string warehouseId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdateWarehouseSettings(HttpClient methodClient, UpdateWarehouseSettingsRequestBody updateWarehouseSettingsRequestBody, string warehouseId, CancellationToken cancellationToken = default);
 
 }
 
@@ -166,8 +166,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createWarehouseRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateWarehouseResponseBody)</returns>
-    public Task<CreateWarehouseResponseBody> CreateWarehouse(CreateWarehouseRequestBody createWarehouseRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateWarehouseResponseBody)</returns>
+    public Task<ShipEngineResponse<CreateWarehouseResponseBody>> CreateWarehouse(CreateWarehouseRequestBody createWarehouseRequestBody, CancellationToken cancellationToken = default)
     {
         return CreateWarehouse(_client, createWarehouseRequestBody, cancellationToken);
     }
@@ -180,8 +180,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createWarehouseRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateWarehouseResponseBody)</returns>
-    public async Task<CreateWarehouseResponseBody> CreateWarehouse(HttpClient methodClient, CreateWarehouseRequestBody createWarehouseRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateWarehouseResponseBody)</returns>
+    public async Task<ShipEngineResponse<CreateWarehouseResponseBody>> CreateWarehouse(HttpClient methodClient, CreateWarehouseRequestBody createWarehouseRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'createWarehouseRequestBody' is set
         if (createWarehouseRequestBody == null)
@@ -196,9 +196,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WarehousesApi.CreateWarehouse";
 
-        var result = await SendHttpRequestAsync<CreateWarehouseResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<CreateWarehouseResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<CreateWarehouseResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -208,8 +209,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> DeleteWarehouse(string warehouseId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> DeleteWarehouse(string warehouseId, CancellationToken cancellationToken = default)
     {
         return DeleteWarehouse(_client, warehouseId, cancellationToken);
     }
@@ -222,8 +223,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> DeleteWarehouse(HttpClient methodClient, string warehouseId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> DeleteWarehouse(HttpClient methodClient, string warehouseId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'warehouseId' is set
         if (warehouseId == null)
@@ -238,9 +239,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WarehousesApi.DeleteWarehouse";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Delete, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -250,8 +252,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetWarehouseByIdResponseBody)</returns>
-    public Task<GetWarehouseByIdResponseBody> GetWarehouseById(string warehouseId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetWarehouseByIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetWarehouseByIdResponseBody>> GetWarehouseById(string warehouseId, CancellationToken cancellationToken = default)
     {
         return GetWarehouseById(_client, warehouseId, cancellationToken);
     }
@@ -264,8 +266,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetWarehouseByIdResponseBody)</returns>
-    public async Task<GetWarehouseByIdResponseBody> GetWarehouseById(HttpClient methodClient, string warehouseId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetWarehouseByIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetWarehouseByIdResponseBody>> GetWarehouseById(HttpClient methodClient, string warehouseId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'warehouseId' is set
         if (warehouseId == null)
@@ -280,9 +282,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WarehousesApi.GetWarehouseById";
 
-        var result = await SendHttpRequestAsync<GetWarehouseByIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetWarehouseByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetWarehouseByIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -291,8 +294,8 @@ public partial class ShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListWarehousesResponseBody)</returns>
-    public Task<ListWarehousesResponseBody> ListWarehouses(CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListWarehousesResponseBody)</returns>
+    public Task<ShipEngineResponse<ListWarehousesResponseBody>> ListWarehouses(CancellationToken cancellationToken = default)
     {
         return ListWarehouses(_client, cancellationToken);
     }
@@ -304,8 +307,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (ListWarehousesResponseBody)</returns>
-    public async Task<ListWarehousesResponseBody> ListWarehouses(HttpClient methodClient, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (ListWarehousesResponseBody)</returns>
+    public async Task<ShipEngineResponse<ListWarehousesResponseBody>> ListWarehouses(HttpClient methodClient, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/warehouses");
@@ -313,9 +316,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WarehousesApi.ListWarehouses";
 
-        var result = await SendHttpRequestAsync<ListWarehousesResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<ListWarehousesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<ListWarehousesResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -326,8 +330,8 @@ public partial class ShipEngine
     /// <param name="updateWarehouseRequestBody"></param>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> UpdateWarehouse(UpdateWarehouseRequestBody updateWarehouseRequestBody, string warehouseId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> UpdateWarehouse(UpdateWarehouseRequestBody updateWarehouseRequestBody, string warehouseId, CancellationToken cancellationToken = default)
     {
         return UpdateWarehouse(_client, updateWarehouseRequestBody, warehouseId, cancellationToken);
     }
@@ -341,8 +345,8 @@ public partial class ShipEngine
     /// <param name="updateWarehouseRequestBody"></param>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> UpdateWarehouse(HttpClient methodClient, UpdateWarehouseRequestBody updateWarehouseRequestBody, string warehouseId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> UpdateWarehouse(HttpClient methodClient, UpdateWarehouseRequestBody updateWarehouseRequestBody, string warehouseId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'updateWarehouseRequestBody' is set
         if (updateWarehouseRequestBody == null)
@@ -364,9 +368,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WarehousesApi.UpdateWarehouse";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -377,8 +382,8 @@ public partial class ShipEngine
     /// <param name="updateWarehouseSettingsRequestBody"></param>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> UpdateWarehouseSettings(UpdateWarehouseSettingsRequestBody updateWarehouseSettingsRequestBody, string warehouseId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> UpdateWarehouseSettings(UpdateWarehouseSettingsRequestBody updateWarehouseSettingsRequestBody, string warehouseId, CancellationToken cancellationToken = default)
     {
         return UpdateWarehouseSettings(_client, updateWarehouseSettingsRequestBody, warehouseId, cancellationToken);
     }
@@ -392,8 +397,8 @@ public partial class ShipEngine
     /// <param name="updateWarehouseSettingsRequestBody"></param>
     /// <param name="warehouseId">Warehouse ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> UpdateWarehouseSettings(HttpClient methodClient, UpdateWarehouseSettingsRequestBody updateWarehouseSettingsRequestBody, string warehouseId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> UpdateWarehouseSettings(HttpClient methodClient, UpdateWarehouseSettingsRequestBody updateWarehouseSettingsRequestBody, string warehouseId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'updateWarehouseSettingsRequestBody' is set
         if (updateWarehouseSettingsRequestBody == null)
@@ -415,9 +420,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WarehousesApi.UpdateWarehouseSettings";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/Api/WarehousesApi.cs
+++ b/ShipEngineSDK/Api/WarehousesApi.cs
@@ -196,10 +196,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WarehousesApi.CreateWarehouse";
 
-        var (data, response) = await GetHttpResponse<CreateWarehouseResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<CreateWarehouseResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<CreateWarehouseResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -239,10 +236,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WarehousesApi.DeleteWarehouse";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -282,10 +276,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WarehousesApi.GetWarehouseById";
 
-        var (data, response) = await GetHttpResponse<GetWarehouseByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetWarehouseByIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetWarehouseByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -316,10 +307,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WarehousesApi.ListWarehouses";
 
-        var (data, response) = await GetHttpResponse<ListWarehousesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<ListWarehousesResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<ListWarehousesResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -368,10 +356,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WarehousesApi.UpdateWarehouse";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -420,10 +405,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WarehousesApi.UpdateWarehouseSettings";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/WebhooksApi.cs
+++ b/ShipEngineSDK/Api/WebhooksApi.cs
@@ -173,10 +173,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WebhooksApi.CreateWebhook";
 
-        var (data, response) = await GetHttpResponse<CreateWebhookResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<CreateWebhookResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<CreateWebhookResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -216,10 +213,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WebhooksApi.DeleteWebhook";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -259,10 +253,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WebhooksApi.GetWebhookById";
 
-        var (data, response) = await GetHttpResponse<GetWebhookByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<GetWebhookByIdResponseBody>(data, response.StatusCode, headers);
+        return await GetHttpResponse<GetWebhookByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -293,10 +284,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WebhooksApi.ListWebhooks";
 
-        var (data, response) = await GetHttpResponse<List<Webhook>>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<List<Webhook>>(data, response.StatusCode, headers);
+        return await GetHttpResponse<List<Webhook>>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     /// <summary>
@@ -345,10 +333,7 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WebhooksApi.UpdateWebhook";
 
-        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
+        return await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
 }

--- a/ShipEngineSDK/Api/WebhooksApi.cs
+++ b/ShipEngineSDK/Api/WebhooksApi.cs
@@ -31,8 +31,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createWebhookRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateWebhookResponseBody)</returns>
-    Task<CreateWebhookResponseBody> CreateWebhook(CreateWebhookRequestBody createWebhookRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateWebhookResponseBody)</returns>
+    Task<ShipEngineResponse<CreateWebhookResponseBody>> CreateWebhook(CreateWebhookRequestBody createWebhookRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create a Webhook Create a webook for specific events in the environment.
@@ -42,8 +42,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createWebhookRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateWebhookResponseBody)</returns>
-    Task<CreateWebhookResponseBody> CreateWebhook(HttpClient methodClient, CreateWebhookRequestBody createWebhookRequestBody, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (CreateWebhookResponseBody)</returns>
+    Task<ShipEngineResponse<CreateWebhookResponseBody>> CreateWebhook(HttpClient methodClient, CreateWebhookRequestBody createWebhookRequestBody, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete Webhook By ID Delete a webhook
@@ -52,8 +52,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="webhookId">Webhook ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DeleteWebhook(string webhookId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DeleteWebhook(string webhookId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete Webhook By ID Delete a webhook
@@ -63,8 +63,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="webhookId">Webhook ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> DeleteWebhook(HttpClient methodClient, string webhookId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> DeleteWebhook(HttpClient methodClient, string webhookId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Webhook By ID Retrieve individual webhook by an ID
@@ -73,8 +73,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="webhookId">Webhook ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetWebhookByIdResponseBody)</returns>
-    Task<GetWebhookByIdResponseBody> GetWebhookById(string webhookId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetWebhookByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetWebhookByIdResponseBody>> GetWebhookById(string webhookId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Get Webhook By ID Retrieve individual webhook by an ID
@@ -84,8 +84,8 @@ public partial interface IShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="webhookId">Webhook ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetWebhookByIdResponseBody)</returns>
-    Task<GetWebhookByIdResponseBody> GetWebhookById(HttpClient methodClient, string webhookId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (GetWebhookByIdResponseBody)</returns>
+    Task<ShipEngineResponse<GetWebhookByIdResponseBody>> GetWebhookById(HttpClient methodClient, string webhookId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Webhooks List all webhooks currently enabled for the account.
@@ -93,8 +93,8 @@ public partial interface IShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;Webhook&gt;)</returns>
-    Task<List<Webhook>> ListWebhooks(CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (List&lt;Webhook&gt;)</returns>
+    Task<ShipEngineResponse<List<Webhook>>> ListWebhooks(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List Webhooks List all webhooks currently enabled for the account.
@@ -103,8 +103,8 @@ public partial interface IShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;Webhook&gt;)</returns>
-    Task<List<Webhook>> ListWebhooks(HttpClient methodClient, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (List&lt;Webhook&gt;)</returns>
+    Task<ShipEngineResponse<List<Webhook>>> ListWebhooks(HttpClient methodClient, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update a Webhook Update the webhook url property
@@ -114,8 +114,8 @@ public partial interface IShipEngine
     /// <param name="updateWebhookRequestBody"></param>
     /// <param name="webhookId">Webhook ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdateWebhook(UpdateWebhookRequestBody updateWebhookRequestBody, string webhookId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdateWebhook(UpdateWebhookRequestBody updateWebhookRequestBody, string webhookId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update a Webhook Update the webhook url property
@@ -126,8 +126,8 @@ public partial interface IShipEngine
     /// <param name="updateWebhookRequestBody"></param>
     /// <param name="webhookId">Webhook ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    Task<string> UpdateWebhook(HttpClient methodClient, UpdateWebhookRequestBody updateWebhookRequestBody, string webhookId, CancellationToken cancellationToken = default);
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    Task<ShipEngineResponse<string>> UpdateWebhook(HttpClient methodClient, UpdateWebhookRequestBody updateWebhookRequestBody, string webhookId, CancellationToken cancellationToken = default);
 
 }
 
@@ -143,8 +143,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="createWebhookRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateWebhookResponseBody)</returns>
-    public Task<CreateWebhookResponseBody> CreateWebhook(CreateWebhookRequestBody createWebhookRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateWebhookResponseBody)</returns>
+    public Task<ShipEngineResponse<CreateWebhookResponseBody>> CreateWebhook(CreateWebhookRequestBody createWebhookRequestBody, CancellationToken cancellationToken = default)
     {
         return CreateWebhook(_client, createWebhookRequestBody, cancellationToken);
     }
@@ -157,8 +157,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="createWebhookRequestBody"></param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (CreateWebhookResponseBody)</returns>
-    public async Task<CreateWebhookResponseBody> CreateWebhook(HttpClient methodClient, CreateWebhookRequestBody createWebhookRequestBody, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (CreateWebhookResponseBody)</returns>
+    public async Task<ShipEngineResponse<CreateWebhookResponseBody>> CreateWebhook(HttpClient methodClient, CreateWebhookRequestBody createWebhookRequestBody, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'createWebhookRequestBody' is set
         if (createWebhookRequestBody == null)
@@ -173,9 +173,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WebhooksApi.CreateWebhook";
 
-        var result = await SendHttpRequestAsync<CreateWebhookResponseBody>(HttpMethods.Post, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<CreateWebhookResponseBody>(HttpMethods.Post, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<CreateWebhookResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -185,8 +186,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="webhookId">Webhook ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> DeleteWebhook(string webhookId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> DeleteWebhook(string webhookId, CancellationToken cancellationToken = default)
     {
         return DeleteWebhook(_client, webhookId, cancellationToken);
     }
@@ -199,8 +200,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="webhookId">Webhook ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> DeleteWebhook(HttpClient methodClient, string webhookId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> DeleteWebhook(HttpClient methodClient, string webhookId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'webhookId' is set
         if (webhookId == null)
@@ -215,9 +216,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WebhooksApi.DeleteWebhook";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Delete, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Delete, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -227,8 +229,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="webhookId">Webhook ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetWebhookByIdResponseBody)</returns>
-    public Task<GetWebhookByIdResponseBody> GetWebhookById(string webhookId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetWebhookByIdResponseBody)</returns>
+    public Task<ShipEngineResponse<GetWebhookByIdResponseBody>> GetWebhookById(string webhookId, CancellationToken cancellationToken = default)
     {
         return GetWebhookById(_client, webhookId, cancellationToken);
     }
@@ -241,8 +243,8 @@ public partial class ShipEngine
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="webhookId">Webhook ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (GetWebhookByIdResponseBody)</returns>
-    public async Task<GetWebhookByIdResponseBody> GetWebhookById(HttpClient methodClient, string webhookId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (GetWebhookByIdResponseBody)</returns>
+    public async Task<ShipEngineResponse<GetWebhookByIdResponseBody>> GetWebhookById(HttpClient methodClient, string webhookId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'webhookId' is set
         if (webhookId == null)
@@ -257,9 +259,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WebhooksApi.GetWebhookById";
 
-        var result = await SendHttpRequestAsync<GetWebhookByIdResponseBody>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<GetWebhookByIdResponseBody>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<GetWebhookByIdResponseBody>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -268,8 +271,8 @@ public partial class ShipEngine
     /// <exception cref="System.ArgumentNullException">Thrown when required argument is null</exception>
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;Webhook&gt;)</returns>
-    public Task<List<Webhook>> ListWebhooks(CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (List&lt;Webhook&gt;)</returns>
+    public Task<ShipEngineResponse<List<Webhook>>> ListWebhooks(CancellationToken cancellationToken = default)
     {
         return ListWebhooks(_client, cancellationToken);
     }
@@ -281,8 +284,8 @@ public partial class ShipEngine
     /// <exception cref="ShipEngineSDK.ShipEngineException">Thrown when fails to make API call</exception>
     /// <param name="methodClient">HttpClient to use for the request</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (List&lt;Webhook&gt;)</returns>
-    public async Task<List<Webhook>> ListWebhooks(HttpClient methodClient, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (List&lt;Webhook&gt;)</returns>
+    public async Task<ShipEngineResponse<List<Webhook>>> ListWebhooks(HttpClient methodClient, CancellationToken cancellationToken = default)
     {
 
         RequestOptions requestOptions = new("/v1/environment/webhooks");
@@ -290,9 +293,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WebhooksApi.ListWebhooks";
 
-        var result = await SendHttpRequestAsync<List<Webhook>>(HttpMethods.Get, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<List<Webhook>>(HttpMethods.Get, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<List<Webhook>>(data, response.StatusCode, headers);
     }
 
     /// <summary>
@@ -303,8 +307,8 @@ public partial class ShipEngine
     /// <param name="updateWebhookRequestBody"></param>
     /// <param name="webhookId">Webhook ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public Task<string> UpdateWebhook(UpdateWebhookRequestBody updateWebhookRequestBody, string webhookId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public Task<ShipEngineResponse<string>> UpdateWebhook(UpdateWebhookRequestBody updateWebhookRequestBody, string webhookId, CancellationToken cancellationToken = default)
     {
         return UpdateWebhook(_client, updateWebhookRequestBody, webhookId, cancellationToken);
     }
@@ -318,8 +322,8 @@ public partial class ShipEngine
     /// <param name="updateWebhookRequestBody"></param>
     /// <param name="webhookId">Webhook ID</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse (string)</returns>
-    public async Task<string> UpdateWebhook(HttpClient methodClient, UpdateWebhookRequestBody updateWebhookRequestBody, string webhookId, CancellationToken cancellationToken = default)
+    /// <returns>Task of ShipEngineResponse (string)</returns>
+    public async Task<ShipEngineResponse<string>> UpdateWebhook(HttpClient methodClient, UpdateWebhookRequestBody updateWebhookRequestBody, string webhookId, CancellationToken cancellationToken = default)
     {
         // verify the required parameter 'updateWebhookRequestBody' is set
         if (updateWebhookRequestBody == null)
@@ -341,9 +345,10 @@ public partial class ShipEngine
 
         requestOptions.Operation = "WebhooksApi.UpdateWebhook";
 
-        var result = await SendHttpRequestAsync<string>(HttpMethods.Put, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<string>(HttpMethods.Put, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<string>(data, response.StatusCode, headers);
     }
 
 }

--- a/ShipEngineSDK/ShipEngineClient.cs
+++ b/ShipEngineSDK/ShipEngineClient.cs
@@ -226,6 +226,13 @@ namespace ShipEngineSDK
         /// <returns></returns>
         public virtual async Task<T> SendHttpRequestAsync<T>(HttpMethod method, string path, string? jsonContent, HttpClient client, Config config, CancellationToken cancellationToken)
         {
+            (T data,  HttpResponseMessage message) = await GetHttpResponse<T>(method, path, jsonContent, client, config, cancellationToken);
+            return data;
+        }
+
+        public async Task<(T, HttpResponseMessage)> GetHttpResponse<T>(HttpMethod method, string path, string? jsonContent, HttpClient client, Config config,
+            CancellationToken cancellationToken)
+        {
             int retry = 0;
 
             HttpResponseMessage? response = null;
@@ -239,8 +246,7 @@ namespace ShipEngineSDK
                     response = await client.SendAsync(request, cancellationToken);
 
                     var deserializedResult = await DeserializedResultOrThrow<T>(response);
-
-                    return deserializedResult;
+                    return (deserializedResult, response);
                 }
                 catch (ShipEngineException e)
                 {

--- a/ShipEngineSDK/ShipEngineClient.cs
+++ b/ShipEngineSDK/ShipEngineClient.cs
@@ -187,11 +187,11 @@ namespace ShipEngineSDK
         /// Builds and sends an HTTP Request to the ShipEngine Client, has special logic for handling
         /// 429 rate limit exceeded errors and subsequent retry logic.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="method"></param>
+        /// <typeparam name="T">Type of data to return</typeparam>
+        /// <param name="method">Http method for the request</param>
         /// <param name="requestOptions">Options for the request</param>
-        /// <param name="client"></param>
-        /// <param name="config"></param>
+        /// <param name="client">Client to use for the request</param>
+        /// <param name="config">Extra configuration for the request</param>
         /// <param name="cancellationToken">Token that can be used to cancel the request</param>
         /// <returns></returns>
         public virtual Task<T> SendHttpRequestAsync<T>(HttpMethod method, RequestOptions requestOptions,
@@ -202,12 +202,12 @@ namespace ShipEngineSDK
         /// Builds and sends an HTTP Request to the ShipEngine Client, has special logic for handling
         /// 429 rate limit exceeded errors and subsequent retry logic.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="method"></param>
-        /// <param name="path"></param>
-        /// <param name="jsonContent"></param>
-        /// <param name="client"></param>
-        /// <param name="config"></param>
+        /// <typeparam name="T">Type of data to return</typeparam>
+        /// <param name="method">Http method for the request</param>
+        /// <param name="path">Path of the request</param>
+        /// <param name="jsonContent">Content to send to the server, already serialized to JSON</param>
+        /// <param name="client">Client to use for the request</param>
+        /// <param name="config">Extra configuration for the request</param>
         /// <returns></returns>
         public virtual Task<T> SendHttpRequestAsync<T>(HttpMethod method, string path, string? jsonContent, HttpClient client, Config config) =>
             SendHttpRequestAsync<T>(method, path, jsonContent, client, config, CancellationToken);
@@ -216,21 +216,33 @@ namespace ShipEngineSDK
         /// Builds and sends an HTTP Request to the ShipEngine Client, has special logic for handling
         /// 429 rate limit exceeded errors and subsequent retry logic.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="method"></param>
-        /// <param name="path"></param>
-        /// <param name="jsonContent"></param>
-        /// <param name="client"></param>
-        /// <param name="config"></param>
+        /// <typeparam name="T">Type of data to return</typeparam>
+        /// <param name="method">Http method for the request</param>
+        /// <param name="path">Path of the request</param>
+        /// <param name="jsonContent">Content to send to the server, already serialized to JSON</param>
+        /// <param name="client">Client to use for the request</param>
+        /// <param name="config">Extra configuration for the request</param>
         /// <param name="cancellationToken">Token that can be used to cancel the request</param>
         /// <returns></returns>
         public virtual async Task<T> SendHttpRequestAsync<T>(HttpMethod method, string path, string? jsonContent, HttpClient client, Config config, CancellationToken cancellationToken)
         {
-            (T data,  HttpResponseMessage message) = await GetHttpResponse<T>(method, path, jsonContent, client, config, cancellationToken);
-            return data;
+            var response = await GetHttpResponse<T>(method, path, jsonContent, client, config, cancellationToken);
+            return response.Data;
         }
 
-        public async Task<(T, HttpResponseMessage)> GetHttpResponse<T>(HttpMethod method, string path, string? jsonContent, HttpClient client, Config config,
+        /// <summary>
+        /// Builds and sends an HTTP Request to the ShipEngine Client, has special logic for handling
+        /// 429 rate limit exceeded errors and subsequent retry logic.
+        /// </summary>
+        /// <typeparam name="T">Type of data to return</typeparam>
+        /// <param name="method">Http method for the request</param>
+        /// <param name="path">Path of the request</param>
+        /// <param name="jsonContent">Content to send to the server, already serialized to JSON</param>
+        /// <param name="client">Client to use for the request</param>
+        /// <param name="config">Extra configuration for the request</param>
+        /// <param name="cancellationToken">Token that can be used to cancel the request</param>
+        /// <returns></returns>
+        public async Task<ShipEngineResponse<T>> GetHttpResponse<T>(HttpMethod method, string path, string? jsonContent, HttpClient client, Config config,
             CancellationToken cancellationToken)
         {
             int retry = 0;
@@ -246,7 +258,7 @@ namespace ShipEngineSDK
                     response = await client.SendAsync(request, cancellationToken);
 
                     var deserializedResult = await DeserializedResultOrThrow<T>(response);
-                    return (deserializedResult, response);
+                    return new(deserializedResult, response);
                 }
                 catch (ShipEngineException e)
                 {

--- a/ShipEngineSDK/ShipEngineResponse.cs
+++ b/ShipEngineSDK/ShipEngineResponse.cs
@@ -1,18 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+
 namespace ShipEngineSDK;
 
-using System.Collections.Generic;
-using System.Net;
-
-public class ShipEngineResponse<T>
+/// <summary>
+/// Response from ShipEngine API that includes the data, status code, and headers
+/// </summary>
+/// <typeparam name="T">Type of data returned from the API</typeparam>
+/// <param name="data">Deserialized data from the API</param>
+/// <param name="message">Response message from the server</param>
+public class ShipEngineResponse<T>(T data, HttpResponseMessage message)
 {
-    private readonly T _data;
-    public HttpStatusCode HttpStatus { get; private init; }
-    public IDictionary<string, string> Headers { get; private init; }
+    /// <summary>
+    /// Data returned from the API
+    /// </summary>
+    public T Data { get; } = data;
 
-    public ShipEngineResponse(T data, HttpStatusCode httpStatus, Dictionary<string, string> headers)
-    {
-        _data = data;
-        HttpStatus = httpStatus;
-        Headers = headers;
-    }
+    /// <summary>
+    /// Status code of the response
+    /// </summary>
+    public HttpStatusCode HttpStatus { get; } = message.StatusCode;
+
+    /// <summary>
+    /// Headers returned from the API
+    /// </summary>
+    public IDictionary<string, string> Headers { get; } = message.Headers
+        .ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(), StringComparer.InvariantCultureIgnoreCase);
 }

--- a/ShipEngineSDK/ShipEngineResponse.cs
+++ b/ShipEngineSDK/ShipEngineResponse.cs
@@ -1,0 +1,18 @@
+namespace ShipEngineSDK;
+
+using System.Collections.Generic;
+using System.Net;
+
+public class ShipEngineResponse<T>
+{
+    private readonly T _data;
+    public HttpStatusCode HttpStatus { get; private init; }
+    public IDictionary<string, string> Headers { get; private init; }
+
+    public ShipEngineResponse(T data, HttpStatusCode httpStatus, Dictionary<string, string> headers)
+    {
+        _data = data;
+        HttpStatus = httpStatus;
+        Headers = headers;
+    }
+}

--- a/generation/templates/api.mustache
+++ b/generation/templates/api.mustache
@@ -238,10 +238,7 @@ namespace {{packageName}};
 
         requestOptions.Operation = "{{classname}}.{{operationId}}";
 
-        var (data, response) = await GetHttpResponse<{{{returnType}}}{{^returnType}}Object{{/returnType}}>(HttpMethods.{{#lambda.titlecase}}{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}{{/lambda.titlecase}}, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
-        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
-            StringComparer.InvariantCultureIgnoreCase);
-        return new ShipEngineResponse<{{{returnType}}}{{^returnType}}Object{{/returnType}}>(data, response.StatusCode, headers);
+        return await GetHttpResponse<{{{returnType}}}{{^returnType}}Object{{/returnType}}>(HttpMethods.{{#lambda.titlecase}}{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}{{/lambda.titlecase}}, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
     }
 
     {{/operation}}

--- a/generation/templates/api.mustache
+++ b/generation/templates/api.mustache
@@ -33,11 +33,11 @@ namespace {{packageName}};
     /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
     {{/allParams}}
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse{{#returnType}} ({{.}}){{/returnType}}</returns>
+    /// <returns>Task of ShipEngineResponse{{#returnType}} ({{.}}){{/returnType}}</returns>
     {{#isDeprecated}}
     [Obsolete]
     {{/isDeprecated}}
-    Task<{{{returnType}}}{{^returnType}}Object{{/returnType}}> {{operationId}}({{#allParams}}{{{dataType}}}{{^required}}?{{/required}} {{paramName}}, {{/allParams}}CancellationToken cancellationToken = default);
+    Task<ShipEngineResponse<{{{returnType}}}{{^returnType}}Object{{/returnType}}>> {{operationId}}({{#allParams}}{{{dataType}}}{{^required}}?{{/required}} {{paramName}}, {{/allParams}}CancellationToken cancellationToken = default);
 
     /// <summary>
     /// {{summary}} {{notes}}
@@ -49,11 +49,11 @@ namespace {{packageName}};
     /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
     {{/allParams}}
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse{{#returnType}} ({{.}}){{/returnType}}</returns>
+    /// <returns>Task of ShipEngineResponse{{#returnType}} ({{.}}){{/returnType}}</returns>
     {{#isDeprecated}}
     [Obsolete]
     {{/isDeprecated}}
-    Task<{{{returnType}}}{{^returnType}}Object{{/returnType}}> {{operationId}}(HttpClient methodClient, {{#allParams}}{{{dataType}}}{{^required}}?{{/required}} {{paramName}}, {{/allParams}}CancellationToken cancellationToken = default);
+    Task<ShipEngineResponse<{{{returnType}}}{{^returnType}}Object{{/returnType}}>> {{operationId}}(HttpClient methodClient, {{#allParams}}{{{dataType}}}{{^required}}?{{/required}} {{paramName}}, {{/allParams}}CancellationToken cancellationToken = default);
 
     {{/operation}}
 }
@@ -73,11 +73,11 @@ namespace {{packageName}};
     /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
     {{/allParams}}
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse{{#returnType}} ({{.}}){{/returnType}}</returns>
+    /// <returns>Task of ShipEngineResponse{{#returnType}} ({{.}}){{/returnType}}</returns>
     {{#isDeprecated}}
     [Obsolete]
     {{/isDeprecated}}
-    public Task<{{{returnType}}}{{^returnType}}Object{{/returnType}}> {{operationId}}({{#allParams}}{{{dataType}}}{{^required}}?{{/required}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default{{/optionalMethodArgument}}{{/required}}, {{/allParams}}CancellationToken cancellationToken = default)
+    public Task<ShipEngineResponse<{{{returnType}}}{{^returnType}}Object{{/returnType}}>> {{operationId}}({{#allParams}}{{{dataType}}}{{^required}}?{{/required}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default{{/optionalMethodArgument}}{{/required}}, {{/allParams}}CancellationToken cancellationToken = default)
     {
         return {{operationId}}(_client, {{#allParams}}{{paramName}}, {{/allParams}}cancellationToken);
     }
@@ -92,11 +92,11 @@ namespace {{packageName}};
     /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
     {{/allParams}}
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-    /// <returns>Task of ApiResponse{{#returnType}} ({{.}}){{/returnType}}</returns>
+    /// <returns>Task of ShipEngineResponse{{#returnType}} ({{.}}){{/returnType}}</returns>
     {{#isDeprecated}}
     [Obsolete]
     {{/isDeprecated}}
-    public async Task<{{{returnType}}}{{^returnType}}Object{{/returnType}}> {{operationId}}(HttpClient methodClient, {{#allParams}}{{{dataType}}}{{^required}}?{{/required}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default{{/optionalMethodArgument}}{{/required}}, {{/allParams}}CancellationToken cancellationToken = default)
+    public async Task<ShipEngineResponse<{{{returnType}}}{{^returnType}}Object{{/returnType}}>> {{operationId}}(HttpClient methodClient, {{#allParams}}{{{dataType}}}{{^required}}?{{/required}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default{{/optionalMethodArgument}}{{/required}}, {{/allParams}}CancellationToken cancellationToken = default)
     {
         {{#allParams}}
         {{#required}}
@@ -238,9 +238,10 @@ namespace {{packageName}};
 
         requestOptions.Operation = "{{classname}}.{{operationId}}";
 
-        var result = await SendHttpRequestAsync<{{{returnType}}}{{^returnType}}Object{{/returnType}}>(HttpMethods.{{#lambda.titlecase}}{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}{{/lambda.titlecase}}, requestOptions, methodClient, _config, cancellationToken);
-
-        return result;
+        var (data, response) = await GetHttpResponse<{{{returnType}}}{{^returnType}}Object{{/returnType}}>(HttpMethods.{{#lambda.titlecase}}{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}{{/lambda.titlecase}}, requestOptions.FullPath(), requestOptions.Data, methodClient, _config, cancellationToken);
+        var headers = response.Headers.ToDictionary(h => h.Key, h => h.Value.FirstOrDefault(),
+            StringComparer.InvariantCultureIgnoreCase);
+        return new ShipEngineResponse<{{{returnType}}}{{^returnType}}Object{{/returnType}}>(data, response.StatusCode, headers);
     }
 
     {{/operation}}


### PR DESCRIPTION
Callers should have access to the response headers - specifically the x-shipengine-request-id.

The significant changes are in `ShipEngineClient`, `ShipEngineResponse` and `api.mustache`. The rest are the result of regeneration.