### PR TITLE
Update request modifiers so they can be scoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,3 +168,12 @@ Fixed handling of No Content responses
 ### Added
 
 - Added basic ability to modify the HttpClient in a request
+
+## 2.3.0
+
+### Added
+
+- Added ability to scope request modifiers by using the `.WithRequestModifier()` method instead of the `.ModifyRequest` property.
+  This will allow consumers to modify a single request without affecting any other consumers of the client. It also allows for
+  multiple modifiers to be added.  For example, a modifier could be added at the global level that applies to all requests and then
+  another modifier can be added for a single request.

--- a/ShipEngineSDK.Test/Helpers/MockShipEngineFixture.cs
+++ b/ShipEngineSDK.Test/Helpers/MockShipEngineFixture.cs
@@ -75,11 +75,13 @@ namespace ShipEngineTest
         /// <param name="path">The HTTP path.</param>
         /// <param name="status">The status code to return.</param>
         /// <param name="response">The response body to return.</param>
-        public string StubRequest(HttpMethod method, string path, HttpStatusCode status, string response)
+        public string StubRequest(HttpMethod method, string path, HttpStatusCode status = HttpStatusCode.OK, string response = null)
         {
             var requestId = Guid.NewGuid().ToString();
-            var responseMessage = new HttpResponseMessage(status);
-            responseMessage.Content = new StringContent(response ?? "");
+            var responseMessage = new HttpResponseMessage(status)
+            {
+                Content = new StringContent(response ?? "")
+            };
             responseMessage.Headers.Add("x-shipengine-requestid", requestId);
             responseMessage.Headers.Add("request-id", requestId);
 

--- a/ShipEngineSDK/ShipEngine.cs
+++ b/ShipEngineSDK/ShipEngine.cs
@@ -1,14 +1,13 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ShipEngineSDK.Common;
-using ShipEngineSDK.Manifests;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Result = ShipEngineSDK.ValidateAddresses.Result;
 
 [assembly: InternalsVisibleTo("ShipEngineSDK.Test")]
 
@@ -226,13 +225,39 @@ namespace ShipEngineSDK
         }
 
         /// <summary>
+        /// Copy constructor that adds a request modifier to the existing collection
+        /// </summary>
+        /// <param name="client">Client to use for requests</param>
+        /// <param name="config">Config to use for the requests</param>
+        /// <param name="requestModifiers">List of request modifiers to use</param>
+        private ShipEngine(HttpClient client, Config config, IEnumerable<Action<HttpRequestMessage>> requestModifiers) :
+            base(requestModifiers)
+        {
+            _client = client;
+            _config = config;
+        }
+
+        /// <summary>
+        /// Gets a new instance of the ShipEngine client with the provided request modifier added to the collection
+        /// </summary>
+        /// <param name="modifier">Request modifier that will be added</param>
+        /// <returns>A new instance of the ShipEngine client</returns>
+        /// <remarks>The existing ShipEngine client is not modified</remarks>
+        public ShipEngine WithRequestModifier(Action<HttpRequestMessage> modifier) =>
+            new(_client, _config, requestModifiers.Append(modifier));
+
+        /// <summary>
         /// Modifies the request before it is sent to the ShipEngine API
         /// </summary>
-        /// <param name="modifyRequest"></param>
-        /// <returns></returns>
+        /// <param name="modifyRequest">Request modifier that will be used</param>
+        /// <returns>The current instance of the ShipEngine client</returns>
+        /// <remarks>
+        /// This method modifies the existing ShipEngine client and will replace any existing request modifiers with the one provided.
+        /// If you want to add a request modifier to the existing collection, use the WithRequestModifier method.
+        /// </remarks>
         public ShipEngine ModifyRequest(Action<HttpRequestMessage> modifyRequest)
         {
-            base.ModifyRequest = modifyRequest;
+            requestModifiers = [modifyRequest];
             return this;
         }
 

--- a/ShipEngineSDK/ShipEngineSDK.csproj
+++ b/ShipEngineSDK/ShipEngineSDK.csproj
@@ -4,7 +4,7 @@
 		<PackageId>ShipEngine</PackageId>
 		<PackageTags>sdk;rest;api;shipping;rates;label;tracking;cost;address;validation;normalization;fedex;ups;usps;</PackageTags>
 
-		<Version>2.2.1</Version>
+		<Version>2.3.0</Version>
 		<Authors>ShipEngine</Authors>
 		<Company>ShipEngine</Company>
 		<Summary>The official ShipEngine C# SDK for .NET</Summary>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shipengine-dotnet",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Package primarily used to generate the API and models from OpenApi spec\"",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Add the ability to scope request modifiers.  The previous behavior set the request modifier on the ShipEngine client, which affected all consumers of the client.  This change instead returns a new instance of the ShipEngine client, appending the request modifier to the existing list of modifiers.  The HttpClient and Config are persisted.